### PR TITLE
Don't send GET request body in proxied requests.

### DIFF
--- a/lib/proxy.js
+++ b/lib/proxy.js
@@ -154,7 +154,7 @@ module.exports = function(options) {
         proxiedRequest = callback(remoteUrl, filteredReqHeaders, proxy, maxAgeSeconds);
     }
 
-    function buildReqHandler(httpVerb) {
+    function buildReqHandler(httpVerb, passRequestBody) {
         return function(req, res, next) {
             return doProxy(req, res, next, function(remoteUrl, filteredRequestHeaders, proxy, maxAgeSeconds) {
                 var proxiedRequest = request[httpVerb]({
@@ -175,7 +175,9 @@ module.exports = function(options) {
                     res.status(code).send(body);
                 });
 
-                req.pipe(proxiedRequest);
+                if (passRequestBody) {
+                    req.pipe(proxiedRequest);
+                }
 
                 return proxiedRequest;
             });
@@ -183,8 +185,8 @@ module.exports = function(options) {
     }
 
     var router = express.Router();
-    router.get('/*', buildReqHandler('get'));
-    router.post('/*', buildReqHandler('post'));
+    router.get('/*', buildReqHandler('get', false));
+    router.post('/*', buildReqHandler('post', true));
 
     return router;
 };


### PR DESCRIPTION
This fixes the problems we're seeing on GA staging server of nationalmap.gov.au.  Here's what's happening.

GA's Apache-based reverse proxy is adding an `X-Forwarded-Host: nationalmap.gov.au` header.  Our Node-based proxy then attempts to exclude this header from the proxied request, as it should.  However, it fails to do so for a rather subtle reason, described below.  So the WA server ends up seeing this header, thinks it should be serving for `nationalmap.gov.au`, and fails because it doesn't know how (nor should it).

Our server explicitly removes `X-Forwarded-Host` headers from proxied requests.  It took my a long time to figure out why it ends up being sent anyway.  The reason is this line in `proxy.js`:

```
req.pipe(proxiedRequest);
```

That line causes _the entire original request_ to be passed to the upstream server, including the header part of the HTTP request!  So all headers passed to the original request get passed straight on through to the upstream server.  Oops!

My solution in this pull request is to simply skip this line for GET requests, since we don't need to send the HTTP body anyway.  For POST, we do need it, so I've left the line.  That means POST requests will still include all of the original headers.  That's bad, but not an immediate problem.

CC @stevage and @AlexGilleran because they'll probably know a better way to fix this that works for POST requests too.

CC @tobybellwood because we should _not_ deploy the new release until this is fixed.  Contrary to what I said before, our 2016-03-15 release will _not_ work even on `nationalmap.gov.au`.