### PR TITLE
Exclude headers

### DIFF
--- a/lib/app.js
+++ b/lib/app.js
@@ -155,6 +155,23 @@ app.get('/ping', function(req, res){
   res.status(200).send('OK');
 });
 
+/*
+// For testing, simply reflects stuff back at the caller. Uncomment if needed.
+app.get('/reflect', function(req, res){
+    res.status(200).send(req.headers);
+});
+var bodyParser = require('body-parser');
+app.post('/reflect', bodyParser.urlencoded({extended: true, type: function() { return true; }}), function(req, res) {
+    var response = {
+        body: req.body,
+        headers: req.headers
+    };
+
+    res.status(200).send(response);
+});
+*/
+
+
 app.use(function(req, res, next) {
     if (show404) {
         res.status(404).sendFile(wwwroot + '/404.html');
@@ -177,8 +194,8 @@ app.use(function(error, req, res, next) {
 
 app.listen(argv.port, listenHost);
 process.on('uncaughtException', function(err) {
-    console.log(err);
-    process.exit(1);
+    console.error(err.stack ? err.stack : err);
+    process.exit(1);    
 });
 
 /*

--- a/lib/proxy.js
+++ b/lib/proxy.js
@@ -171,24 +171,16 @@ module.exports = function(options) {
                         console.error(err);
                         res.status(500).send('Proxy error');
                     }).on('response', function(response) {
-                        var code;
-
-                        if (response) {
-                            code = response.statusCode;
-                            res.header(processHeaders(response.headers, maxAgeSeconds));
-                            response.on('data', function(chunk) {
-                                res.write(chunk);
-                            });
-                            response.on('end', function() {
-                                res.end();
-                            });
-                        } else {
-                            code = 500;
-                        }
-
-                        res.status(code);
+                        res.status(response.statusCode);
+                        res.header(processHeaders(response.headers, maxAgeSeconds));
+                        response.on('data', function(chunk) {
+                            res.write(chunk);
+                        });
+                        response.on('end', function() {
+                            res.end();
+                        });
                     });
-                } catch(e) {
+                } catch (e) {
                     console.error(e.stack);
                     res.status(500).send('Proxy error');
                 }

--- a/lib/proxy.js
+++ b/lib/proxy.js
@@ -2,8 +2,9 @@
 "use strict";
 
 var express = require('express');
-var request = require('request');
+var defaultRequest = require('request');
 var url = require('url');
+var bodyParser = require('body-parser');
 
 var DO_NOT_PROXY_REGEX = /^(?:Host|X-Forwarded-Host|Proxy-Connection|Connection|Keep-Alive|Transfer-Encoding|TE|Trailer|Proxy-Authorization|Proxy-Authenticate|Upgrade|Expires|pragma)$/i;
 var PROTOCOL_REGEX = /^\w+:\//;
@@ -36,6 +37,7 @@ var DEFAULT_MAX_AGE_SECONDS = 1209600; // two weeks
  * @returns {*} A middleware that can be used with express.
  */
 module.exports = function(options) {
+    var request = options.request || defaultRequest; //overridable for tests
     var proxyDomains = options.proxyDomains || [];
     var proxyAllDomains = options.proxyAllDomains || !proxyDomains.length;
     var proxyAuth = options.proxyAuth || {};
@@ -157,25 +159,39 @@ module.exports = function(options) {
     function buildReqHandler(httpVerb) {
         return function(req, res, next) {
             return doProxy(req, res, next, function(remoteUrl, filteredRequestHeaders, proxy, maxAgeSeconds) {
-                var proxiedRequest = request[httpVerb]({
-                    url: url.format(remoteUrl),
-                    headers: filteredRequestHeaders,
-                    encoding: null,
-                    proxy: proxy
-                }, function(error, response, body) {
-                    var code;
+                try {
+                    var proxiedRequest = request({
+                        method: httpVerb,
+                        url: url.format(remoteUrl),
+                        headers: filteredRequestHeaders,
+                        encoding: null,
+                        proxy: proxy,
+                        body: req.body
+                    }).on('error', function(err) {
+                        console.error(err);
+                        res.status(500).send('Proxy error');
+                    }).on('response', function(response) {
+                        var code;
 
-                    if (response) {
-                        code = response.statusCode;
-                        res.header(processHeaders(response.headers, maxAgeSeconds));
-                    } else {
-                        code = 500;
-                    }
+                        if (response) {
+                            code = response.statusCode;
+                            res.header(processHeaders(response.headers, maxAgeSeconds));
+                            response.on('data', function(chunk) {
+                                res.write(chunk);
+                            });
+                            response.on('end', function() {
+                                res.end();
+                            });
+                        } else {
+                            code = 500;
+                        }
 
-                    res.status(code).send(body);
-                });
-
-                req.pipe(proxiedRequest);
+                        res.status(code);
+                    });
+                } catch(e) {
+                    console.error(e.stack);
+                    res.status(500).send('Proxy error');
+                }
 
                 return proxiedRequest;
             });
@@ -184,7 +200,7 @@ module.exports = function(options) {
 
     var router = express.Router();
     router.get('/*', buildReqHandler('get'));
-    router.post('/*', buildReqHandler('post'));
+    router.post('/*', bodyParser.raw({type: function() { return true;}}), buildReqHandler('post'));
 
     return router;
 };

--- a/package.json
+++ b/package.json
@@ -23,6 +23,7 @@
   },
   "homepage": "https://github.com/TerriaJS/TerriaJS-Server",
   "dependencies": {
+    "body-parser": "^1.15.0",
     "compression": "^1.6.0",
     "cors": "^2.7.1",
     "express": "^4.8.0",


### PR DESCRIPTION
Rival to https://github.com/TerriaJS/terriajs-server/pull/9.

- Fixes the problem described in that PR where the entire request was being passed through including headers
- Adds unit tests for this case
- Makes the requests that come back stream directly to the client instead of waiting for the entire request to come back and then passing it all at once.

So in addition to fixing that problem this should make all our proxy requests a bit quicker and a bit more memory efficient :).