### PR TITLE
Add feedback service

### DIFF
--- a/lib/app.js
+++ b/lib/app.js
@@ -225,6 +225,7 @@ var initPaths = configSettings.initPaths || [];
 if (serveWwwRoot) {
     initPaths.push(path.join(wwwroot, 'init'));
 }
+
 app.use('/init', require('./initfile')(initPaths, error404, path.dirname(configFile)));
 /*
 // For testing, simply reflects stuff back at the caller. Uncomment if needed.
@@ -241,6 +242,11 @@ app.post('/reflect', bodyParser.urlencoded({extended: true, type: function() { r
     res.status(200).send(response);
 });
 */
+
+var feedbackService = require('./feedback')(configSettings.feedback);
+if (feedbackService) {
+    app.use('/feedback', feedbackService);
+}
 
 app.use(error404);
 app.use(error500);

--- a/lib/feedback.js
+++ b/lib/feedback.js
@@ -35,12 +35,11 @@ module.exports = function(options) {
                 body: formatBody(req, parameters)
             })
         }, function(error, response, body) {
-            console.log(response.statusCode);
-            console.log(body);
+            res.set('Content-Type', 'application/json');
             if (response.statusCode < 200 || response.statusCode >= 300) {
-                res.status(response.statusCode).send('Feedback posting failed');
+                res.status(response.statusCode).send(JSON.stringify({result: 'FAILED'}));
             } else {
-                res.status(200).send('Feedback posted');
+                res.status(200).send(JSON.stringify({result: 'SUCCESS'}));
             }
         });
 

--- a/lib/feedback.js
+++ b/lib/feedback.js
@@ -27,7 +27,7 @@ module.exports = function(options) {
             url: createIssueUrl,
             method: 'POST',
             headers: {
-                'User-Agent': 'TerriaBot (TerriaJS Feedback)',
+                'User-Agent': options.userAgent || 'TerriaBot (TerriaJS Feedback)',
                 'Accept': 'application/vnd.github.v3+json'
             },
             body: JSON.stringify({

--- a/lib/feedback.js
+++ b/lib/feedback.js
@@ -19,10 +19,6 @@ module.exports = function(options) {
     router.post('/', function(req, res, next) {
         var parameters = req.body;
 
-        if (!parameters.title) {
-            res.status(400).send('title is required');
-        }
-
         request({
             url: createIssueUrl,
             method: 'POST',
@@ -31,7 +27,7 @@ module.exports = function(options) {
                 'Accept': 'application/vnd.github.v3+json'
             },
             body: JSON.stringify({
-                title: parameters.title,
+                title: 'User Feedback',
                 body: formatBody(req, parameters)
             })
         }, function(error, response, body) {
@@ -51,11 +47,12 @@ module.exports = function(options) {
 function formatBody(request, parameters) {
     var result = '';
 
+    result += '* Name: ' + (parameters.name ? parameters.name : 'Not provided') + '\n';
+    result += '* Email Address: ' + (parameters.email ? parameters.email : 'Not provided') + '\n';
     result += '* IP Address: ' + request.ip + '\n';
     result += '* Referrer: ' + request.header('Referrer') + '\n';
-    result += '* Email Address: ' + (parameters.email ? parameters.email : 'Not provided') + '\n';
     result += '\n';
-    result += parameters.body;
+    result += parameters.comment ? parameters.comment : 'No comment provided';
 
     return result;
 }

--- a/lib/feedback.js
+++ b/lib/feedback.js
@@ -27,7 +27,7 @@ module.exports = function(options) {
                 'Accept': 'application/vnd.github.v3+json'
             },
             body: JSON.stringify({
-                title: 'User Feedback',
+                title: parameters.title ? parameters.title : 'User Feedback',
                 body: formatBody(req, parameters)
             })
         }, function(error, response, body) {

--- a/lib/feedback.js
+++ b/lib/feedback.js
@@ -1,0 +1,62 @@
+/* jshint node: true */
+'use strict';
+
+var bodyParser = require('body-parser');
+var router = require('express').Router();
+var url = require('url');
+var request = require('request');
+
+module.exports = function(options) {
+    if (!options || !options.issuesUrl || !options.accessToken) {
+        return;
+    }
+
+    var parsedCreateIssueUrl = url.parse(options.issuesUrl, true);
+    parsedCreateIssueUrl.query.access_token = options.accessToken;
+    var createIssueUrl = url.format(parsedCreateIssueUrl);
+
+    router.use(bodyParser.json());
+    router.post('/', function(req, res, next) {
+        var parameters = req.body;
+
+        if (!parameters.title) {
+            res.status(400).send('title is required');
+        }
+
+        request({
+            url: createIssueUrl,
+            method: 'POST',
+            headers: {
+                'User-Agent': 'TerriaBot (TerriaJS Feedback)',
+                'Accept': 'application/vnd.github.v3+json'
+            },
+            body: JSON.stringify({
+                title: parameters.title,
+                body: formatBody(req, parameters)
+            })
+        }, function(error, response, body) {
+            console.log(response.statusCode);
+            console.log(body);
+            if (response.statusCode < 200 || response.statusCode >= 300) {
+                res.status(response.statusCode).send('Feedback posting failed');
+            } else {
+                res.status(200).send('Feedback posted');
+            }
+        });
+
+    });
+
+    return router;
+};
+
+function formatBody(request, parameters) {
+    var result = '';
+
+    result += '* IP Address: ' + request.ip + '\n';
+    result += '* Referrer: ' + request.header('Referrer') + '\n';
+    result += '* Email Address: ' + (parameters.email ? parameters.email : 'Not provided') + '\n';
+    result += '\n';
+    result += parameters.body;
+
+    return result;
+}


### PR DESCRIPTION
Adds a `/feedback` service.  When properly configured with a GitHub access token in the server config file, it allows feedback issues to be created by posting a title, body, and email address.  If not configured, the service is not added.