### PR TITLE
Append to X-Forwarded-For if it already exists.

### DIFF
--- a/lib/controllers/proxy.js
+++ b/lib/controllers/proxy.js
@@ -145,7 +145,9 @@ module.exports = function(options) {
         });
 
         var filteredReqHeaders = filterHeaders(req.headers);
-        if (!filteredReqHeaders['x-forwarded-for']) {
+        if (filteredReqHeaders['x-forwarded-for']) {
+            filteredReqHeaders['x-forwarded-for'] = filteredReqHeaders['x-forwarded-for'] + ', ' + req.connection.remoteAddress;
+        } else {
             filteredReqHeaders['x-forwarded-for'] = req.connection.remoteAddress;
         }
 


### PR DESCRIPTION
This means that if a client is passing a fake `X-Forwarded-For` header then we will still append their real source ip.