### PR TITLE
Require node >= 4.0, instead of strictly requiring 4.x.

### DIFF
--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
   "description": "NodeJS server for TerriaJS, consisting of a CORS proxy, proj4 CRS lookup service, ogr2ogr conversion service, and express static server.",
   "engineStrict": true,
   "engines": {
-    "node": "^4.0.0"
+    "node": ">=4.0.0"
   },
   "main": "lib/app.js",
   "scripts": {


### PR DESCRIPTION
We've had this wrong all along, but I just noticed because [yarn](https://github.com/yarnpkg/yarn) seems to actually enforce it.