### PR TITLE
2119 add shareurl to feedback

### DIFF
--- a/lib/controllers/feedback.js
+++ b/lib/controllers/feedback.js
@@ -49,12 +49,12 @@ function formatBody(request, parameters) {
 
     result += parameters.comment ? parameters.comment : 'No comment provided';
     result += '\n### User details\n';
-    result += '* Name: ' + (parameters.name ? parameters.name : 'Not provided') + '\n';
+    result += '* Name: '          + (parameters.name ? parameters.name : 'Not provided') + '\n';
     result += '* Email Address: ' + (parameters.email ? parameters.email : 'Not provided') + '\n';
-    result += '* IP Address: ' + request.ip + '\n';
-    result += '* User Agent: ' + request.header('User-Agent') + '\n';
-    result += '* Referrer: ' + request.header('Referrer') + '\n';
-    result += '* Share URL: ' + parameters.shareLink + '\n';
+    result += '* IP Address: '    + request.ip + '\n';
+    result += '* User Agent: '    + request.header('User-Agent') + '\n';
+    result += '* Referrer: '      + request.header('Referrer') + '\n';
+    result += '* Share URL: '     + (parameters.shareLink ? parameters.shareLink : 'Not provided') + '\n';
 
     return result;
 }

--- a/lib/controllers/feedback.js
+++ b/lib/controllers/feedback.js
@@ -47,13 +47,14 @@ module.exports = function(options) {
 function formatBody(request, parameters) {
     var result = '';
 
+    result += parameters.comment ? parameters.comment : 'No comment provided';
+    result += '\n---\n';
     result += '* Name: ' + (parameters.name ? parameters.name : 'Not provided') + '\n';
     result += '* Email Address: ' + (parameters.email ? parameters.email : 'Not provided') + '\n';
     result += '* IP Address: ' + request.ip + '\n';
     result += '* User Agent: ' + request.header('User-Agent') + '\n';
     result += '* Referrer: ' + request.header('Referrer') + '\n';
-    result += '\n';
-    result += parameters.comment ? parameters.comment : 'No comment provided';
+    result += '* Share URL: ' + parameters.shareLink + '\n';
 
     return result;
 }

--- a/lib/controllers/feedback.js
+++ b/lib/controllers/feedback.js
@@ -48,7 +48,7 @@ function formatBody(request, parameters) {
     var result = '';
 
     result += parameters.comment ? parameters.comment : 'No comment provided';
-    result += '\n---\n';
+    result += '\n### User details\n';
     result += '* Name: ' + (parameters.name ? parameters.name : 'Not provided') + '\n';
     result += '* Email Address: ' + (parameters.email ? parameters.email : 'Not provided') + '\n';
     result += '* IP Address: ' + request.ip + '\n';


### PR DESCRIPTION
Adds the share url sent by TerriaJS (see terriajs#2243) to the feedback sent to github, and reorder so comments show up in email snippets before user details.