### PR TITLE
Make `npm stop` / `stop_server.sh` work on Windows systems.

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,3 +1,7 @@
+### 2.6.4
+
+* Made `npm stop` / `stop_server.sh` work on Windows systems.
+
 ### 2.6.3
 
 * Don't let Express URL decode the path passed to the proxy service.

--- a/stop_server.sh
+++ b/stop_server.sh
@@ -1,11 +1,7 @@
 if [ -f "terriajs.pid" ]; then
     pid=`cat "terriajs.pid"`
-    ps | grep "^ *${pid}" > /dev/null
-    running=$?
-    if [ $running -eq 0 ]; then
-        echo "(Killing old server)."
-        kill $pid
-    fi
+    echo "(Killing old server)."
+    node -e "require('process').kill(${pid})"
 else
     echo "TerriaJS server not running."
 fi


### PR DESCRIPTION
The problem was that node was being used to get the process ID, yielding a Windows process ID.  But then we were trying to use the unixy `kill` command to stop it, which expected a unixy process ID.  The change here is to use node to kill the process too.

The terriajs.pid file still isn't cleaned up properly on Windows because the SIGTERM handler is never called, but we can live with that.