### PR TITLE
Support for custom auth headers

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,3 +1,7 @@
+### 2.6.7
+
+* Added support for server-supplied custom headers, by extending the process used to insert the basic http auth header `authorization`.
+
 ### 2.6.6
 
 * Fixed a bug that caused `Content-Length: 0` to be included in proxied GET requests.

--- a/lib/controllers/proxy.js
+++ b/lib/controllers/proxy.js
@@ -162,10 +162,10 @@ module.exports = function(options) {
                 // http basic auth.
                 filteredReqHeaders['authorization'] = authRequired.authorization;
             }
-            if (authRequired.parameters) {
+            if (authRequired.headers) {
                 // a mechanism to pass arbitrary headers.
-                authRequired.parameters.forEach(function(parameter) {
-                    filteredReqHeaders[parameter.key] = parameter.value;
+                authRequired.headers.forEach(function(header) {
+                    filteredReqHeaders[header.name] = header.value;
                 });
             }
         }

--- a/lib/controllers/proxy.js
+++ b/lib/controllers/proxy.js
@@ -156,12 +156,19 @@ module.exports = function(options) {
             delete filteredReqHeaders['authorization'];
         }
 
-        // http basic auth
         var authRequired = proxyAuth[remoteUrl.host];
         if (authRequired) {
-            filteredReqHeaders['authorization'] = authRequired.authorization;
+            if (authRequired.authorization) {
+                // http basic auth.
+                filteredReqHeaders['authorization'] = authRequired.authorization;
+            }
+            if (authRequired.parameters) {
+                // a mechanism to pass arbitrary headers.
+                authRequired.parameters.forEach(function(parameter) {
+                    filteredReqHeaders[parameter.key] = parameter.value;
+                });
+            }
         }
-
 
         proxiedRequest = callback(remoteUrl, filteredReqHeaders, proxy, maxAgeSeconds);
     }

--- a/proxyauth.json.example
+++ b/proxyauth.json.example
@@ -10,11 +10,11 @@
     // This allows you to pass other pre-specified headers (typically for authentication or authorization).
 
     "some.other.service.example.com": {
-        "parameters": [{
-             "key": "Secret-Key",
+        "headers": [{
+             "name": "Secret-Key",
              "value": "ABCDE12345"
          }, {
-             "key": "Another-Key",
+             "name": "Another-Header",
              "value": "XYZ"
          }]
     }

--- a/proxyauth.json.example
+++ b/proxyauth.json.example
@@ -11,11 +11,11 @@
 
     "some.other.service.example.com": {
         "parameters": [{
-             key: "Secret-Key",
-             value: "ABCDE12345"
+             "key": "Secret-Key",
+             "value": "ABCDE12345"
          }, {
-             key: "Another-Key",
-             value: "XYZ"
+             "key": "Another-Key",
+             "value": "XYZ"
          }]
     }
 }

--- a/proxyauth.json.example
+++ b/proxyauth.json.example
@@ -1,7 +1,21 @@
 {
-    // This allows hosts which require basic HTTP auth to be proxied for. Warning: You are essentially bypassing security for this host and exposing it to
-    // the web, so you may want to combine this with another security mechanism such as an IP whitelist.
+    // This allows hosts which require basic HTTP auth to be proxied for.
+    // Warning: You are essentially bypassing security for this host and exposing it to the web,
+    // so you may want to combine this with another security mechanism such as an IP whitelist.
+
     "www.some.remote.service.example.com": {
         "authorization": "Basic dGVzdHVzZXI6dGVzdHBhc3MK"
+    },
+
+    // This allows you to pass other pre-specified headers (typically for authentication or authorization).
+
+    "some.other.service.example.com": {
+        "parameters": [{
+             key: "Secret-Key",
+             value: "ABCDE12345"
+         }, {
+             key: "Another-Key",
+             value: "XYZ"
+         }]
     }
 }

--- a/spec/proxy.spec.js
+++ b/spec/proxy.spec.js
@@ -307,7 +307,7 @@ describe('proxy', function() {
             });
         });
 
-        describe('when domain has authentication specified', function() {
+        describe('when domain has basic authentication specified', function() {
             it('should set an auth header for that domain', function(done) {
                 request(buildApp({
                     proxyAllDomains: true,
@@ -337,6 +337,56 @@ describe('proxy', function() {
                     .expect(200)
                     .expect(function() {
                         expect(fakeRequest.calls.argsFor(0)[0].headers.authorization).toBeUndefined();
+                        expect(fakeRequest.calls.argsFor(0)[0].method).toBe(verb);
+                    })
+                    .end(assert(done));
+            });
+        });
+
+        describe('when domain has other headers specified', function() {
+            it('should set the header for that domain', function(done) {
+                request(buildApp({
+                    proxyAllDomains: true,
+                    proxyAuth: {
+                        'example.com': {
+                            "parameters": [{
+                                 key: "Secret-Key",
+                                 value: "ABCDE12345"
+                             }, {
+                                 key: "Another-Key",
+                                 value: "XYZ"
+                             }]
+                        }
+                    }
+                }))[methodName]('/example.com/auth')
+                    .expect(200)
+                    .expect(function() {
+                        expect(fakeRequest.calls.argsFor(0)[0].headers['Secret-Key']).toBe('ABCDE12345');
+                        expect(fakeRequest.calls.argsFor(0)[0].headers['Another-Key']).toBe('XYZ');
+                        expect(fakeRequest.calls.argsFor(0)[0].method).toBe(verb);
+                    })
+                    .end(assert(done));
+            });
+
+            it('should not set the headers for other domains', function(done) {
+                request(buildApp({
+                    proxyAllDomains: true,
+                    proxyAuth: {
+                        'example2.com': {
+                            "parameters": [{
+                                 key: "Secret-Key",
+                                 value: "ABCDE12345"
+                             }, {
+                                 key: "Another-Key",
+                                 value: "XYZ"
+                             }]
+                        }
+                    }
+                }))[methodName]('/example.com/auth')
+                    .expect(200)
+                    .expect(function() {
+                        expect(fakeRequest.calls.argsFor(0)[0].headers['Secret-Key']).toBeUndefined();
+                        expect(fakeRequest.calls.argsFor(0)[0].headers['Another-Key']).toBeUndefined();
                         expect(fakeRequest.calls.argsFor(0)[0].method).toBe(verb);
                     })
                     .end(assert(done));

--- a/spec/proxy.spec.js
+++ b/spec/proxy.spec.js
@@ -349,11 +349,11 @@ describe('proxy', function() {
                     proxyAllDomains: true,
                     proxyAuth: {
                         'example.com': {
-                            "parameters": [{
-                                 key: "Secret-Key",
+                            "headers": [{
+                                 name: "Secret-Key",
                                  value: "ABCDE12345"
                              }, {
-                                 key: "Another-Key",
+                                 name: "Another-Header",
                                  value: "XYZ"
                              }]
                         }
@@ -362,7 +362,7 @@ describe('proxy', function() {
                     .expect(200)
                     .expect(function() {
                         expect(fakeRequest.calls.argsFor(0)[0].headers['Secret-Key']).toBe('ABCDE12345');
-                        expect(fakeRequest.calls.argsFor(0)[0].headers['Another-Key']).toBe('XYZ');
+                        expect(fakeRequest.calls.argsFor(0)[0].headers['Another-Header']).toBe('XYZ');
                         expect(fakeRequest.calls.argsFor(0)[0].method).toBe(verb);
                     })
                     .end(assert(done));
@@ -373,11 +373,11 @@ describe('proxy', function() {
                     proxyAllDomains: true,
                     proxyAuth: {
                         'example2.com': {
-                            "parameters": [{
-                                 key: "Secret-Key",
+                            "headers": [{
+                                 name: "Secret-Key",
                                  value: "ABCDE12345"
                              }, {
-                                 key: "Another-Key",
+                                 name: "Another-Header",
                                  value: "XYZ"
                              }]
                         }
@@ -386,7 +386,7 @@ describe('proxy', function() {
                     .expect(200)
                     .expect(function() {
                         expect(fakeRequest.calls.argsFor(0)[0].headers['Secret-Key']).toBeUndefined();
-                        expect(fakeRequest.calls.argsFor(0)[0].headers['Another-Key']).toBeUndefined();
+                        expect(fakeRequest.calls.argsFor(0)[0].headers['Another-Header']).toBeUndefined();
                         expect(fakeRequest.calls.argsFor(0)[0].method).toBe(verb);
                     })
                     .end(assert(done));


### PR DESCRIPTION
Adds support for server-supplied custom headers, by extending the process used to insert the basic http auth header `authorization`.

Improves on #66.

This is required for Protari, but may be more general purpose.