### PR TITLE
terriajs 2588 server implementation

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,5 +1,9 @@
 ### 2.6.7
 
+* Added esri-token-auth service which is able to request tokens from ESRI token servers with username / password authentication and forward them on to anonymous clients.
+
+### 2.6.7
+
 * Allow setting the size limit for proxy POST requests using `proxyPostSizeLimit` in the server config. If no unit is specified bytes is assumed, or use some reasonable unit like 'kb' for kilobytes or 'mb' for megabytes.
 
 ### 2.6.6

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,4 +1,4 @@
-### 2.6.7
+### 2.7.0
 
 * Added esri-token-auth service which is able to request tokens from ESRI token servers with username / password authentication and forward them on to anonymous clients.
 

--- a/lib/controllers/esri-token-auth.js
+++ b/lib/controllers/esri-token-auth.js
@@ -1,47 +1,87 @@
 /* jshint node: true, esnext: true */
 "use strict";
-var express = require('express');
+var router = require('express').Router();
+var request = require('request');
+var bodyParser = require('body-parser');
+var url = require('url');
 
-// Expose a whitelisted set of configuration attributes to the world. This definitely doesn't include authorisation tokens, local file paths, etc.
-// It mirrors the structure of the real config file.
 module.exports = function(options) {
-    var router = express.Router();
-    var settings = Object.assign({}, options.settings), safeSettings = {};
-    var safeAttributes = ['allowProxyFor', 'maxConversionSize', 'newShareUrlPrefix', 'proxyAllDomains'];
-    safeAttributes.forEach(key => safeSettings[key] = settings[key]);
-    safeSettings.version = require('../../package.json').version;
-    if (typeof settings.shareUrlPrefixes === 'object') {
-        safeSettings.shareUrlPrefixes = {};
-        Object.keys(settings.shareUrlPrefixes).forEach(function(key) {
-            safeSettings.shareUrlPrefixes[key] = { service: settings.shareUrlPrefixes[key].service };
-        });
+    if (!options || !options.servers) {
+        return;
     }
 
+    // The maximum size of the JSON data.
+    let postSizeLimit = options.postSizeLimit || '1024';
+
+    let tokenServers = parseUrls(options.servers);
+
+    router.use(bodyParser.json({limit:postSizeLimit, type:'application/json'}));
     router.post('/', function(req, res, next) {
-        res.status(200).send(safeSettings);
+        let parameters = req.body;
 
+        if (!parameters.url || parameters.url.length === 0) {
+            return res.status(400).send('No URL specified.');
+        }
 
-        var parameters = req.body;
+        let targetUrl = parseURL(parameters.url);
+        if (!targetUrl || targetUrl.length === 0 && (typeof targetUrl === string)) {
+            return res.status(400).send('Invalid URL specified.');
+        }
 
-                request({
-                    url: 'http://services.ga.gov.au/site_13/rest/services/PSMA_Land_Tenure_Boundaries_ACT_Secure/MapServer',
-                    method: 'POST',
-                    headers: {
-                        'User-Agent': options.userAgent || 'TerriaESRITokenAuth',
-                        'Accept': 'application/vnd.github.v3+json'
-                    },
-                    body: JSON.stringify({
-                        title: parameters.title ? parameters.title : 'User Feedback',
-                        body: formatBody(req, parameters)
-                    })
-                }, function(error, response, body) {
-                    res.set('Content-Type', 'application/json');
-                    if (response.statusCode < 200 || response.statusCode >= 300) {
-                        res.status(response.statusCode).send(JSON.stringify({result: 'FAILED'}));
-                    } else {
-                        res.status(200).send(JSON.stringify({result: 'SUCCESS'}));
-                    }
-                });
+        let tokenServer = tokenServers[targetUrl];
+        if (!tokenServer) {
+            return res.status(400).send('Unsupported URL specified.');
+        }
+
+        if (!tokenServer.username || !tokenServer.password || !tokenServer.tokenUrl) {
+            console.error("Bad Configuration. " + targetUrl + " does not supply all of the required properties.");
+            return res.status(400).send('Invalid server configuration.');
+        }
+
+        request({
+            url: tokenServer.tokenUrl,
+            method: 'POST',
+            headers: {
+                'User-Agent': 'TerriaJSESRITokenAuth',
+            },
+            form:{
+                username: tokenServer.username,
+                password: tokenServer.password,
+                expiration: '1', // todo remove this, in place for developer testing.
+                f: 'JSON'
+            }
+        }, function(error, response, body) {
+            res.set('Content-Type', 'application/json');
+
+            if (response.statusCode != 200) {
+                return res.status(400).send('Token server failed.');
+            } else {
+                let value = JSON.parse(response.body);
+                return res.status(200).send(JSON.stringify(value));
+            }
+        });
     });
+
+    router.use(function(err, req, res, next) {
+        console.error(err.stack);
+        res.status(400).send('Unknown error.');
+    });
+
     return router;
 };
+
+function parseUrls(servers) {
+    let result = {};
+
+    for(var server in servers) {
+        // Note: We should really validate here that the URL is HTTPS to save us from ourselves,
+        // but the current servers we need to support don't support HTTPS :(.
+        result[parseURL(server)] = servers[server];
+    }
+
+    return result;
+}
+
+function parseURL(urlString) {
+    return url.format(url.parse(urlString));
+}

--- a/lib/controllers/esri-token-auth.js
+++ b/lib/controllers/esri-token-auth.js
@@ -78,7 +78,7 @@ module.exports = function(options) {
 function parseUrls(servers) {
     let result = {};
 
-    for(var server in servers) {
+    Object.keys(servers).forEach(server => {
         let parsedUrl = parseUrl(server)
         // Note: We should really validate here that the URL is HTTPS to save us from ourselves,
         // but the current servers we need to support don't support HTTPS :(.
@@ -88,7 +88,7 @@ function parseUrls(servers) {
         else {
             console.error('Invalid configuration. The URL: \'' + server + '\' is not valid.');
         }
-    }
+    });
 
     return result;
 }

--- a/lib/controllers/esri-token-auth.js
+++ b/lib/controllers/esri-token-auth.js
@@ -61,7 +61,7 @@ module.exports = function(options) {
                 }
             }
             catch (error) {
-                return res.status(500).send('Error processing server responce.');
+                return res.status(500).send('Error processing server response.');
             }
         });
     });

--- a/lib/controllers/esri-token-auth.js
+++ b/lib/controllers/esri-token-auth.js
@@ -47,7 +47,6 @@ module.exports = function(options) {
             form:{
                 username: tokenServer.username,
                 password: tokenServer.password,
-                expiration: '1', // todo remove this, in place for developer testing.
                 f: 'JSON'
             }
         }, function(error, response, body) {

--- a/lib/controllers/esri-token-auth.js
+++ b/lib/controllers/esri-token-auth.js
@@ -52,7 +52,7 @@ module.exports = function(options) {
         }, function(error, response, body) {
             res.set('Content-Type', 'application/json');
 
-            if (response.statusCode != 200) {
+            if (response.statusCode !== 200) {
                 return res.status(400).send('Token server failed.');
             } else {
                 let value = JSON.parse(response.body);

--- a/lib/controllers/esri-token-auth.js
+++ b/lib/controllers/esri-token-auth.js
@@ -19,6 +19,29 @@ module.exports = function(options) {
 
     router.post('/', function(req, res, next) {
         res.status(200).send(safeSettings);
+
+
+        var parameters = req.body;
+
+                request({
+                    url: 'http://services.ga.gov.au/site_13/rest/services/PSMA_Land_Tenure_Boundaries_ACT_Secure/MapServer',
+                    method: 'POST',
+                    headers: {
+                        'User-Agent': options.userAgent || 'TerriaESRITokenAuth',
+                        'Accept': 'application/vnd.github.v3+json'
+                    },
+                    body: JSON.stringify({
+                        title: parameters.title ? parameters.title : 'User Feedback',
+                        body: formatBody(req, parameters)
+                    })
+                }, function(error, response, body) {
+                    res.set('Content-Type', 'application/json');
+                    if (response.statusCode < 200 || response.statusCode >= 300) {
+                        res.status(response.statusCode).send(JSON.stringify({result: 'FAILED'}));
+                    } else {
+                        res.status(200).send(JSON.stringify({result: 'SUCCESS'}));
+                    }
+                });
     });
     return router;
 };

--- a/lib/controllers/esri-token-auth.js
+++ b/lib/controllers/esri-token-auth.js
@@ -24,7 +24,7 @@ module.exports = function(options) {
         }
 
         let targetUrl = parseURL(parameters.url);
-        if (!targetUrl || targetUrl.length === 0 && (typeof targetUrl === string)) {
+        if (!targetUrl || (targetUrl.length === 0) || (typeof targetUrl !== 'string')) {
             return res.status(400).send('Invalid URL specified.');
         }
 

--- a/lib/controllers/esri-token-auth.js
+++ b/lib/controllers/esri-token-auth.js
@@ -19,7 +19,7 @@ module.exports = function(options) {
     router.post('/', function(req, res, next) {
         let parameters = req.body;
 
-        if (!parameters.url || parameters.url.length === 0) {
+        if (!parameters.url) {
             return res.status(400).send('No URL specified.');
         }
 

--- a/lib/controllers/esri-token-auth.js
+++ b/lib/controllers/esri-token-auth.js
@@ -35,7 +35,7 @@ module.exports = function(options) {
 
         if (!tokenServer.username || !tokenServer.password || !tokenServer.tokenUrl) {
             console.error("Bad Configuration. " + targetUrl + " does not supply all of the required properties.");
-            return res.status(400).send('Invalid server configuration.');
+            return res.status(500).send('Invalid server configuration.');
         }
 
         request({
@@ -53,7 +53,7 @@ module.exports = function(options) {
             res.set('Content-Type', 'application/json');
 
             if (response.statusCode !== 200) {
-                return res.status(400).send('Token server failed.');
+                return res.status(502).send('Token server failed.');
             } else {
                 let value = JSON.parse(response.body);
                 return res.status(200).send(JSON.stringify(value));

--- a/lib/controllers/esri-token-auth.js
+++ b/lib/controllers/esri-token-auth.js
@@ -66,12 +66,6 @@ module.exports = function(options) {
         });
     });
 
-    // Handle JSON parsing errors as well as any other possible router errors.
-    router.use(function(err, req, res, next) {
-        console.error(err.stack);
-        res.status(400).send('Unknown error.');
-    });
-
     return router;
 };
 

--- a/lib/controllers/esri-token-auth.js
+++ b/lib/controllers/esri-token-auth.js
@@ -73,14 +73,25 @@ function parseUrls(servers) {
     let result = {};
 
     for(var server in servers) {
+        let parsedUrl = parseURL(server)
         // Note: We should really validate here that the URL is HTTPS to save us from ourselves,
         // but the current servers we need to support don't support HTTPS :(.
-        result[parseURL(server)] = servers[server];
+        if (parsedUrl) {
+            result[parsedUrl] = servers[server];
+        }
+        else {
+            console.error('Invalid configuration. The URL: \'' + server + '\' is not valid.');
+        }
     }
 
     return result;
 }
 
 function parseURL(urlString) {
-    return url.format(url.parse(urlString));
+    try {
+        return url.format(url.parse(urlString));
+    }
+    catch (error) {
+        return "";
+    }
 }

--- a/lib/controllers/esri-token-auth.js
+++ b/lib/controllers/esri-token-auth.js
@@ -1,0 +1,24 @@
+/* jshint node: true, esnext: true */
+"use strict";
+var express = require('express');
+
+// Expose a whitelisted set of configuration attributes to the world. This definitely doesn't include authorisation tokens, local file paths, etc.
+// It mirrors the structure of the real config file.
+module.exports = function(options) {
+    var router = express.Router();
+    var settings = Object.assign({}, options.settings), safeSettings = {};
+    var safeAttributes = ['allowProxyFor', 'maxConversionSize', 'newShareUrlPrefix', 'proxyAllDomains'];
+    safeAttributes.forEach(key => safeSettings[key] = settings[key]);
+    safeSettings.version = require('../../package.json').version;
+    if (typeof settings.shareUrlPrefixes === 'object') {
+        safeSettings.shareUrlPrefixes = {};
+        Object.keys(settings.shareUrlPrefixes).forEach(function(key) {
+            safeSettings.shareUrlPrefixes[key] = { service: settings.shareUrlPrefixes[key].service };
+        });
+    }
+
+    router.post('/', function(req, res, next) {
+        res.status(200).send(safeSettings);
+    });
+    return router;
+};

--- a/lib/controllers/esri-token-auth.js
+++ b/lib/controllers/esri-token-auth.js
@@ -23,7 +23,7 @@ module.exports = function(options) {
             return res.status(400).send('No URL specified.');
         }
 
-        let targetUrl = parseURL(parameters.url);
+        let targetUrl = parseUrl(parameters.url);
         if (!targetUrl || (targetUrl.length === 0) || (typeof targetUrl !== 'string')) {
             return res.status(400).send('Invalid URL specified.');
         }
@@ -73,7 +73,7 @@ function parseUrls(servers) {
     let result = {};
 
     for(var server in servers) {
-        let parsedUrl = parseURL(server)
+        let parsedUrl = parseUrl(server)
         // Note: We should really validate here that the URL is HTTPS to save us from ourselves,
         // but the current servers we need to support don't support HTTPS :(.
         if (parsedUrl) {
@@ -87,7 +87,7 @@ function parseUrls(servers) {
     return result;
 }
 
-function parseURL(urlString) {
+function parseUrl(urlString) {
     try {
         return url.format(url.parse(urlString));
     }

--- a/lib/controllers/esri-token-auth.js
+++ b/lib/controllers/esri-token-auth.js
@@ -66,6 +66,7 @@ module.exports = function(options) {
         });
     });
 
+    // Handle JSON parsing errors as well as any other possible router errors.
     router.use(function(err, req, res, next) {
         console.error(err.stack);
         res.status(400).send('Unknown error.');

--- a/lib/controllers/esri-token-auth.js
+++ b/lib/controllers/esri-token-auth.js
@@ -50,13 +50,18 @@ module.exports = function(options) {
                 f: 'JSON'
             }
         }, function(error, response, body) {
-            res.set('Content-Type', 'application/json');
+            try {
+                res.set('Content-Type', 'application/json');
 
-            if (response.statusCode !== 200) {
-                return res.status(502).send('Token server failed.');
-            } else {
-                let value = JSON.parse(response.body);
-                return res.status(200).send(JSON.stringify(value));
+                if (response.statusCode !== 200) {
+                    return res.status(502).send('Token server failed.');
+                } else {
+                    let value = JSON.parse(response.body);
+                    return res.status(200).send(JSON.stringify(value));
+                }
+            }
+            catch (error) {
+                return res.status(500).send('Error processing server responce.');
             }
         });
     });

--- a/lib/makeserver.js
+++ b/lib/makeserver.js
@@ -99,6 +99,8 @@ module.exports = function(options) {
         basicAuthentication: options.settings.basicAuthentication
     }));
 
+    endpoint('/esri-token-auth', require('./controllers/esri-token-auth')(options));
+
     endpoint('/proj4def', require('./controllers/proj4lookup'));            // Proj4def lookup service, to avoid downloading all definitions into the client.
     endpoint('/convert', require('./controllers/convert')(options).router); // OGR2OGR wrapper to allow supporting file types like Shapefile.
     endpoint('/proxyabledomains', require('./controllers/proxydomains')({   // Returns JSON list of domains we're willing to proxy for

--- a/lib/makeserver.js
+++ b/lib/makeserver.js
@@ -99,7 +99,10 @@ module.exports = function(options) {
         basicAuthentication: options.settings.basicAuthentication
     }));
 
-    endpoint('/esri-token-auth', require('./controllers/esri-token-auth')(options));
+    var esriTokenAuth = require('./controllers/esri-token-auth')(options.settings.esriTokenAuth);
+    if (esriTokenAuth) {
+        endpoint('/esri-token-auth', esriTokenAuth);
+    }
 
     endpoint('/proj4def', require('./controllers/proj4lookup'));            // Proj4def lookup service, to avoid downloading all definitions into the client.
     endpoint('/convert', require('./controllers/convert')(options).router); // OGR2OGR wrapper to allow supporting file types like Shapefile.

--- a/serverconfig.json.example
+++ b/serverconfig.json.example
@@ -30,6 +30,18 @@
       "server.example.com"
     ],
 
+    // List of URLs and parameters to request tokens.
+    "esriTokenAuth": {
+        "postSizeLimit": 1024,
+        "servers": {
+            "https://example.com/somelayer": {
+                "username": "myusername",
+                "password": "mypassword",
+                "tokenUrl": "https://example.com/tokens/generateToken"
+            }
+        }
+    }
+
     // Enables and configures the feedback service.  This service accepts posted JSON like:
     //   {
     //       "name":"My Name",

--- a/serverconfig.json.example
+++ b/serverconfig.json.example
@@ -31,6 +31,8 @@
     ],
 
     // List of URLs and parameters to request tokens.
+    // Be careful using this configuration as this configuration effectively currently opens up access to these services and allows anyone to
+    // anonymously mint tokens for the specified server using these credentials.
     "esriTokenAuth": {
         "postSizeLimit": 1024,
         "servers": {


### PR DESCRIPTION
This implementation is insecure in that it effectively takes a service which is secured by username and password and allows anyone (everyone) to anonymously mint tokens for this service. This implementation only obfuscates token generation and worse it masks the fact that the layer was secured and now it is not and becomes effectively publicly available (effectively anyone could mint tokens using this service and then connect directly to the server by-passing authentication for as long token is valid). This implementation does not currently explicitly log information about the clients requesting tokens. If this is problematic in the future further steps should be taken to secure this operation such as authenticating the user prior to minting tokens and taking security more seriously such as logging client information and securing connections between the client and esri token server (see more details later).

Please pay particular attention to security considerations and vulnerabilities as I have not written code like this before and so may have made rookie mistakes and overlooked security issues. One thing that does stand out for me is whether I have done enough to sanitize `targetUrl` and then used it like so `tokenServers[targetUrl];` and whether anything malicious could be done here.

This code does not take security seriously as it permits code between both this server and the token server (terriajs-server -> esri token server) and between terriajs and this server (terriajs -> terriajs-server) to be unencrypted (non TLS). Between terriajs-server and the esri token server this allows both the username / password and token in plain text (unencrypted) and so all the information could be used by an attacker. Similarly between terriajs and terriajs-server the token is in plain text and could be intercepted by an attacker (this connection is particularly vulnerable as it is between the client and server and so has increased risk that the connection has opportunity for attack -> i.e. free unencrypted wifi or some such). Ideally the server would enforce that both of these connections be conducted over the most recent version of TLS, however unfortunately the services that we must authenticate do not correctly support TLS and so we are unable to test or enforce this correctly.