### PR TITLE
[TerriaJS/terriaJS#2588] esri-token-auth: Add warnings to console.error for bad configurations.

### DIFF
--- a/lib/controllers/esri-token-auth.js
+++ b/lib/controllers/esri-token-auth.js
@@ -86,7 +86,7 @@ function parseUrl(urlString) {
         return url.format(url.parse(urlString));
     }
     catch (error) {
-        return "";
+        return '';
     }
 }
 
@@ -114,7 +114,7 @@ function validateServerConfig(servers)
 
 function isHttps(urlString){
     try {
-        return (url.parse(urlString).protocol === "https:")
+        return (url.parse(urlString).protocol === 'https:')
     }
     catch (error)
     {

--- a/lib/controllers/esri-token-auth.js
+++ b/lib/controllers/esri-token-auth.js
@@ -14,6 +14,7 @@ module.exports = function(options) {
     let postSizeLimit = options.postSizeLimit || '1024';
 
     let tokenServers = parseUrls(options.servers);
+    tokenServers = validateServerConfig(tokenServers);
 
     router.use(bodyParser.json({limit:postSizeLimit, type:'application/json'}));
     router.post('/', function(req, res, next) {
@@ -31,11 +32,6 @@ module.exports = function(options) {
         let tokenServer = tokenServers[targetUrl];
         if (!tokenServer) {
             return res.status(400).send('Unsupported URL specified.');
-        }
-
-        if (!tokenServer.username || !tokenServer.password || !tokenServer.tokenUrl) {
-            console.error("Bad Configuration. " + targetUrl + " does not supply all of the required properties.");
-            return res.status(500).send('Invalid server configuration.');
         }
 
         request({
@@ -74,8 +70,6 @@ function parseUrls(servers) {
 
     Object.keys(servers).forEach(server => {
         let parsedUrl = parseUrl(server)
-        // Note: We should really validate here that the URL is HTTPS to save us from ourselves,
-        // but the current servers we need to support don't support HTTPS :(.
         if (parsedUrl) {
             result[parsedUrl] = servers[server];
         }
@@ -93,5 +87,37 @@ function parseUrl(urlString) {
     }
     catch (error) {
         return "";
+    }
+}
+
+function validateServerConfig(servers)
+{
+    let result = {};
+
+    Object.keys(servers).forEach(url => {
+        let server = servers[url];
+        if (server.username && server.password && server.tokenUrl) {
+            result[url] = server;
+
+            // Note: We should really only validate URLs that are HTTPS to save us from ourselves, but the current
+            // servers we need to support don't support HTTPS :( so the best that we can do is warn against it.
+            if (!isHttps(server.tokenUrl)) {
+                console.error('All communications should be TLS but the URL \'' + server.tokenUrl + '\' does not use https.');
+            }
+        } else {
+            console.error('Bad Configuration. \'' + url + '\' does not supply all of the required properties.');
+        }
+    });
+
+    return result;
+}
+
+function isHttps(urlString){
+    try {
+        return (url.parse(urlString).protocol === "https:")
+    }
+    catch (error)
+    {
+        return false;
     }
 }


### PR DESCRIPTION
This implementation only warns against HTTPS being used between the terriajs-server and the esri token server. It does not warn against HTTPS in the layer URL between the client and the layer server (which would expose the token), but technically the URL here is a guide since the client could do or send the token anywhere.