### PR TITLE
Proxy improvements

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -4,6 +4,7 @@
 * Running with `--public false` now runs just a single server process, to support easier debugging.
 * Improved validation of the Esri token configuration.
 * Fixed a problem where a proxy error (such as an invalid content length) detected after the proxy had started sending the response would cause the worker to crash with an exception saying "Can't set headers after they are sent."
+* Added `Strict-Transport-Security` to the list of response headers that are not passed through to the client by the proxy.
 
 ### 2.7.0
 

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -3,6 +3,7 @@
 * Added support for server-supplied custom headers, by extending the process used to insert the basic http auth header `authorization`.
 * Running with `--public false` now runs just a single server process, to support easier debugging.
 * Improved validation of the Esri token configuration.
+* Fixed a problem where a proxy error (such as an invalid content length) detected after the proxy had started sending the response would cause the worker to crash with an exception saying "Can't set headers after they are sent."
 
 ### 2.7.0
 

--- a/lib/controllers/proxy.js
+++ b/lib/controllers/proxy.js
@@ -7,7 +7,7 @@ var defaultRequest = require('request');
 var url = require('url');
 var bodyParser = require('body-parser');
 
-var DO_NOT_PROXY_REGEX = /^(?:Host|X-Forwarded-Host|Proxy-Connection|Connection|Keep-Alive|Transfer-Encoding|TE|Trailer|Proxy-Authorization|Proxy-Authenticate|Upgrade|Expires|pragma)$/i;
+var DO_NOT_PROXY_REGEX = /^(?:Host|X-Forwarded-Host|Proxy-Connection|Connection|Keep-Alive|Transfer-Encoding|TE|Trailer|Proxy-Authorization|Proxy-Authenticate|Upgrade|Expires|pragma|Strict-Transport-Security)$/i;
 var PROTOCOL_REGEX = /^\w+:\//;
 var DURATION_REGEX = /^([\d.]+)(ms|s|m|h|d|w|y)$/;
 var DURATION_UNITS = {

--- a/lib/controllers/proxy.js
+++ b/lib/controllers/proxy.js
@@ -189,7 +189,15 @@ module.exports = function(options) {
                         body: req.body
                     }).on('error', function(err) {
                         console.error(err);
-                        res.status(500).send('Proxy error');
+
+                        // Ideally we would return an error to the client, but if headers have already been sent,
+                        // attempting to set a status code here will fail. So in that case, we'll just end the response,
+                        // for lack of a better option.
+                        if (res.headersSent) {
+                            res.end();
+                        } else {
+                            res.status(500).send('Proxy error');
+                        }
                     }).on('response', function(response) {
                         res.status(response.statusCode);
                         res.header(processHeaders(response.headers, maxAgeSeconds));


### PR DESCRIPTION
* Fixed a problem where a proxy error (such as an invalid content length) detected after the proxy had started sending the response would cause the worker to crash with an exception saying "Can't set headers after they are sent."
* Added `Strict-Transport-Security` to the list of response headers that are not passed through to the client by the proxy.

Fixes #76 
Fixes #77 
