### PR TITLE
Retry without credentials after 403.

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,3 +1,7 @@
+### 2.7.2
+
+* When using `--proxy-auth` to automatically supply HTTP basic authentication credentials, and the remote server returns 403 (Forbidden), we now retry the request without the credentials. This will usually result in the server responding with a 401 (Unauthorized), causing the user's browser to prompt for credentials. This is useful when some of the resources on the server are not available with the automatic credentials but will work if more powerful credentials are supplied.
+
 ### 2.7.1
 
 * Added support for server-supplied custom headers, by extending the process used to insert the basic http auth header `authorization`.

--- a/lib/controllers/proxy.js
+++ b/lib/controllers/proxy.js
@@ -62,7 +62,7 @@ module.exports = function(options) {
         return false;
     }
 
-    function doProxy(req, res, next, callback) {
+    function doProxy(req, res, next, retryWithoutAuth, callback) {
         var remoteUrlString = req.url.substring(1);
 
         if (!remoteUrlString || remoteUrlString.length === 0) {
@@ -159,17 +159,21 @@ module.exports = function(options) {
             delete filteredReqHeaders['authorization'];
         }
 
-        var authRequired = proxyAuth[remoteUrl.host];
-        if (authRequired) {
-            if (authRequired.authorization) {
-                // http basic auth.
-                filteredReqHeaders['authorization'] = authRequired.authorization;
-            }
-            if (authRequired.headers) {
-                // a mechanism to pass arbitrary headers.
-                authRequired.headers.forEach(function(header) {
-                    filteredReqHeaders[header.name] = header.value;
-                });
+        if (!retryWithoutAuth) {
+            var authRequired = proxyAuth[remoteUrl.host];
+            if (authRequired) {
+                if (authRequired.authorization) {
+                    // http basic auth.
+                    if (!filteredReqHeaders['authorization']) {
+                        filteredReqHeaders['authorization'] = authRequired.authorization;
+                    }
+                }
+                if (authRequired.headers) {
+                    // a mechanism to pass arbitrary headers.
+                    authRequired.headers.forEach(function(header) {
+                        filteredReqHeaders[header.name] = header.value;
+                    });
+                }
             }
         }
 
@@ -177,8 +181,8 @@ module.exports = function(options) {
     }
 
     function buildReqHandler(httpVerb) {
-        return function(req, res, next) {
-            return doProxy(req, res, next, function(remoteUrl, filteredRequestHeaders, proxy, maxAgeSeconds) {
+        function handler(req, res, next) {
+            return doProxy(req, res, next, req.retryWithoutAuth, function(remoteUrl, filteredRequestHeaders, proxy, maxAgeSeconds) {
                 try {
                     var proxiedRequest = request({
                         method: httpVerb,
@@ -199,6 +203,15 @@ module.exports = function(options) {
                             res.status(500).send('Proxy error');
                         }
                     }).on('response', function(response) {
+                        if (!req.retryWithoutAuth && response.statusCode === 403 && proxyAuth[remoteUrl.host]) {
+                            // We automatically added an authentication header to this request (e.g. from proxyauth.json),
+                            // but got back a 403, indicating our credentials didn't authorize access to this resource.
+                            // Try again without credentials in order to give the user the opportunity to supply
+                            // their own.
+                            req.retryWithoutAuth = true;
+                            return handler(req, res, next);
+                        }
+
                         res.status(response.statusCode);
                         res.header(processHeaders(response.headers, maxAgeSeconds));
                         response.on('data', function(chunk) {
@@ -216,6 +229,8 @@ module.exports = function(options) {
                 return proxiedRequest;
             });
         }
+
+        return handler;
     }
 
     var router = express.Router();


### PR DESCRIPTION
When using `--proxy-auth` to automatically supply HTTP basic authentication credentials, and the remote server returns 403 (Forbidden), we now retry the request without the credentials. This will usually result in the server responding with a 401 (Unauthorized), causing the user's browser to prompt for credentials. This is useful when some of the resources on the server are not available with the automatic credentials but will work if more powerful credentials are supplied.

Fixes TerriaJS/nationalmap#766
