### PR TITLE
Add option to redirect to HTTPS

### DIFF
--- a/lib/makeserver.js
+++ b/lib/makeserver.js
@@ -59,7 +59,23 @@ module.exports = function(options) {
       res.status(200).send('OK');
     });
 
-    // We do this after the /ping service above so that ping can be used unauthenticated for health checks.
+    // We do this after the /ping service above so that ping can be used unauthenticated and without TLS for health checks.
+
+    if (options.settings.redirectToHttps) {
+        var httpAllowedHosts = options.settings.httpAllowedHosts || ["localhost"];
+        app.use(function(req, res, next) {
+            if (httpAllowedHosts.indexOf(req.hostname) >= 0) {
+                return next();
+            }
+
+            if (req.protocol !== 'https') {
+                var url = 'https://' + req.hostname + req.url;
+                res.redirect(301, url);
+            } else {
+                next();
+            }
+        });
+    }
 
     var auth = options.settings.basicAuthentication;
     if (auth && auth.username && auth.password) {

--- a/serverconfig.json.example
+++ b/serverconfig.json.example
@@ -152,5 +152,17 @@
         // openssl req -nodes -new -x509 -keyout key.pem -out cert.pem
         key: 'key.pem',
         cert: 'cert.pem'
+    },
+
+    // True to automatically redirect `http` requests to `https`.
+    // If `trustProxy` is defined, the protocol will be determined from the `X-Forwarded-Proto` header
+    // if it exists. The default is false.
+    redirectToHttps: true,
+
+    // The list of hosts for which `http` access is allowed, even if `redirectToHttps` is true.
+    // This is mostly useful to allow non-https access to localhost in development.
+    // The default is `["localhost"]`.
+    httpAllowedHosts: [
+        "localhost"
     }
 }


### PR DESCRIPTION
Add this to your server config:

```
    "redirectToHttps": true,
```

You can also add a list of hosts for which requests will _not_ be redirect:

```
    "httpAllowedHosts": [
        "localhost"
    ]
```

It defaults to `localhost`, as above.

All requests (including the proxy) will be redirected except `/ping`.

Fixes TerriaJS/terriajs#3075
