### PR TITLE
Support creating Gists on Enterprise GitHub accounts

### DIFF
--- a/lib/controllers/share.js
+++ b/lib/controllers/share.js
@@ -5,7 +5,7 @@ var bodyParser = require('body-parser');
 var requestp = require('request-promise');
 var rperrors = require('request-promise/errors');
 
-var gistAPI = 'https://api.github.com/gists';
+var githubGistAPI = 'https://api.github.com/gists';
 var googleUrlShortenerAPI = 'https://www.googleapis.com/urlshortener/v1';
 
 var prefixSeparator = '-'; // change the regex below if you change this
@@ -17,6 +17,7 @@ function makeGist(serviceOptions, body) {
     var gistFile = {};
     gistFile[serviceOptions.gistFilename || 'usercatalog.json'] = { content: body };
 
+    gistAPI = serviceOptions.gistAPI || githubGistAPI;
     var headers = {
         'User-Agent': serviceOptions.userAgent || 'TerriaJS-Server',
         'Accept': 'application/vnd.github.v3+json'
@@ -50,6 +51,7 @@ function resolveGist(serviceOptions, id) {
         'User-Agent': serviceOptions.userAgent || 'TerriaJS-Server',
         'Accept': 'application/vnd.github.v3+json'
     };
+    gistAPI = serviceOptions.gistAPI || githubGistAPI;
     if (serviceOptions.accessToken !== undefined) {
         headers['Authorization'] = 'token ' + serviceOptions.accessToken;
     }

--- a/serverconfig.json.example
+++ b/serverconfig.json.example
@@ -158,6 +158,9 @@
             // usage limits apply
             // accessToken: "ABC123",
 
+            // Optional: your enterprise Github API URL goes here. If not supplied, Github's default api will be used
+            // gistAPI : "https://api.github.example.com/gists",
+
             // Optional: user agent HTTP Header to set
             userAgent: "My service",
             // Optional: The filename to give to the gist file (default: usercatalog.json)


### PR DESCRIPTION
GitHub Enterprise supports self-hosted GitHub server. It should be possible to provide a custom Gist API URL as opposed to GitHub's default API,