### PR TITLE
Fix fs.unlink call failing

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,3 +1,7 @@
+### 2.9._
+
+* Fixed throwing an exception in a worker after conversion service runs on Nodejs verions 10+.
+
 ### 2.9.0
 
 * Added automatic rate limiting of failed authentication attempts.

--- a/lib/controllers/convert.js
+++ b/lib/controllers/convert.js
@@ -78,7 +78,7 @@ function convertStream(stream, req, res, hint, fpath) {
                 send('Unable to convert this data file. For a list of formats supported by Terria, see http://www.gdal.org/ogr_formats.html .');
         }
         if (fpath) {
-            fs.unlink(fpath); // clean up the temporary file on disk
+            fs.unlinkSync(fpath); // clean up the temporary file on disk
         }
     });
 }


### PR DESCRIPTION
`fs.unlink` is currently used without a callback but node.js versions 10+ throw an exception on missing callback. Use `fs.unlinkSync` in its place.