### PR TITLE
Increase limit on post body size for share endpoint

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,3 +1,7 @@
+### 3.0.1
+
+* Increase post limit to 200kb on `share` endpoint.
+
 ### 3.0.0
 
 * Switched to [pm2](http://pm2.keymetrics.io/) for managing the server process.

--- a/lib/controllers/share.js
+++ b/lib/controllers/share.js
@@ -143,7 +143,10 @@ module.exports = function(shareUrlPrefixes, newShareUrlPrefix, hostName, port) {
     }
 
     var router = require('express').Router();
-    router.use(bodyParser.text({type: '*/*'}));
+    router.use(bodyParser.text({
+        type: '*/*',
+        limit: '200kb'
+    }));
 
     // Requested creation of a new short URL.
     router.post('/', function(req, res, next) {


### PR DESCRIPTION
This increases the accepted size of post data to the `share` endpoint. This ought to resolve issue https://github.com/terriajs/terriajs/issues/3510 

