### PR TITLE
Assign additional params to the query string on a proxied url

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,3 +1,7 @@
+### 3.2.0
+
+* Support appending additional parameters to a querystring via the `/proxy` endpoint.
+
 ### 3.1.0
 
 * Added support for the HTTP Strict-Transport-Security (HSTS) header.

--- a/lib/controllers/proxy.js
+++ b/lib/controllers/proxy.js
@@ -47,6 +47,7 @@ module.exports = function(options) {
     var proxyDomains = options.proxyableDomains || [];
     var proxyAuth = options.proxyAuth || {};
     var proxyPostSizeLimit = options.proxyPostSizeLimit || '102400';
+    var appendParamToQueryString = options.appendParamToQueryString || {}
 
     // If you change this, also change the same list in serverconfig.json.example.
     // This page is helpful: https://en.wikipedia.org/wiki/Reserved_IP_addresses
@@ -160,6 +161,17 @@ module.exports = function(options) {
 
         // Copy the query string
         remoteUrl.search = url.parse(req.url).search;
+
+        if (appendParamToQueryString[remoteUrl.host]) {
+            const params = appendParamToQueryString[remoteUrl.host]
+            const paramsString = Object.keys(params).map(key => (key+ '=' + params[key])).join('&');
+            if (remoteUrl.search === null) {
+                remoteUrl.search = paramsString
+            } else {
+                var joiner = (remoteUrl.search.indexOf('?') >= 0) ? '&' : '?';
+                remoteUrl.search += joiner + paramsString;
+            }
+        }
 
         if (!remoteUrl.protocol) {
             remoteUrl.protocol = 'http:';

--- a/lib/controllers/proxy.js
+++ b/lib/controllers/proxy.js
@@ -163,13 +163,21 @@ module.exports = function(options) {
         remoteUrl.search = url.parse(req.url).search;
 
         if (appendParamToQueryString[remoteUrl.host]) {
-            const params = appendParamToQueryString[remoteUrl.host]
-            const paramsString = Object.keys(params).map(key => (key+ '=' + params[key])).join('&');
-            if (remoteUrl.search === null) {
-                remoteUrl.search = paramsString
-            } else {
-                var joiner = (remoteUrl.search.indexOf('?') >= 0) ? '&' : '?';
-                remoteUrl.search += joiner + paramsString;
+            const options = appendParamToQueryString[remoteUrl.host];
+
+            for (var i = 0; i < options.length; i++) {
+                const option = options[i];
+                const re = new RegExp(option.regexPattern, "g");
+                const params = option.params;
+                if (re.test(remoteUrl.href)) {
+                    const paramsString = Object.keys(params).map(key => (key+ '=' + params[key])).join('&');
+                    if (remoteUrl.search === null) {
+                        remoteUrl.search = paramsString;
+                    } else {
+                        var joiner = (remoteUrl.search.indexOf('?') >= 0) ? '&' : '?';
+                        remoteUrl.search += joiner + paramsString;
+                    }                    
+                }
             }
         }
 

--- a/lib/makeserver.js
+++ b/lib/makeserver.js
@@ -122,7 +122,8 @@ module.exports = function(options) {
         upstreamProxy: options.settings.upstreamProxy,
         bypassUpstreamProxyHosts: bypassUpstreamProxyHostsMap,
         basicAuthentication: options.settings.basicAuthentication,
-        blacklistedAddresses: options.settings.blacklistedAddresses
+        blacklistedAddresses: options.settings.blacklistedAddresses,
+        appendParamToQueryString: options.settings.appendParamToQueryString
     }));
 
     var esriTokenAuth = require('./controllers/esri-token-auth')(options.settings.esriTokenAuth);

--- a/serverconfig.json.example
+++ b/serverconfig.json.example
@@ -191,12 +191,18 @@
         "localhost"
     ],
 
-    // A object of domain values for which additional parameters are appended to the url querystring.
+    // An array of options which you to inform which additional parameters are appended to the url querystring.
     // By default no additional parameters are appended.
-    // Eg a request to somedomain.com becomes somedomain.com?apikey=123
+    // A regex pattern is used to test whether parameters whould be attached. Set to '.' to match everything
+    // Eg a request to somedomain.com/secured becomes somedomain.com/secured?apikey=123
     "appendParamToQueryString": {
-        "somedomain.com": {
-            "apikey": "123"
-        }
+        "somedomain.com": [
+            {
+                "regexPattern": "secured",
+                "params": {
+                    "apikey": "123"
+                }
+            }
+        ]   
     }
 }

--- a/serverconfig.json.example
+++ b/serverconfig.json.example
@@ -189,5 +189,14 @@
     // The default is `["localhost"]`.
     httpAllowedHosts: [
         "localhost"
-    ]
+    ],
+
+    // A object of domain values for which additional parameters are appended to the url querystring.
+    // By default no additional parameters are appended.
+    // Eg a request to somedomain.com becomes somedomain.com?apikey=123
+    "appendParamToQueryString": {
+        "somedomain.com": {
+            "apikey": "123"
+        }
+    }
 }

--- a/serverconfig.json.example
+++ b/serverconfig.json.example
@@ -193,7 +193,7 @@
 
     // An array of options which you to inform which additional parameters are appended to the url querystring.
     // By default no additional parameters are appended.
-    // A regex pattern is used to test whether parameters whould be attached. Set to '.' to match everything
+    // A regex pattern is used to test whether parameters should be attached. Set to '.' to match everything
     // Eg a request to somedomain.com/secured becomes somedomain.com/secured?apikey=123
     "appendParamToQueryString": {
         "somedomain.com": [

--- a/spec/proxy.spec.js
+++ b/spec/proxy.spec.js
@@ -409,9 +409,12 @@ describe('proxy', function() {
                 request(buildApp({
                     proxyAllDomains: true,
                     appendParamToQueryString: {
-                        "example.com": {
-                            "foo": "bar"
-                        }
+                        "example.com": [{
+                            "regexPattern": ".",
+                            "params": {
+                               "foo": "bar"
+                            }
+                        }]
                     }
                 }))[methodName]('/example.com')
                     .expect(200)
@@ -422,14 +425,85 @@ describe('proxy', function() {
                     .end(assert(done));
             });
 
+            it('append params to the querystring for a specified domain using specified regex', function(done) {
+                request(buildApp({
+                    proxyAllDomains: true,
+                    appendParamToQueryString: {
+                        "example.com": [{
+                            "regexPattern": "something",
+                            "params": {
+                               "foo": "bar"
+                            }
+                        }]
+                    }
+                }))[methodName]('/example.com/something/else')
+                    .expect(200)
+                    .expect(function() {
+                        const hitUrl = new URL(fakeRequest.calls.argsFor(0)[0].url)                        
+                        expect(hitUrl.searchParams.get('foo')).toBe('bar');
+                    })
+                    .end(assert(done));
+            });
+
+            it('no params appended when mismatch in regex', function(done) {
+                request(buildApp({
+                    proxyAllDomains: true,
+                    appendParamToQueryString: {
+                        "example.com": [{
+                            "regexPattern": "something",
+                            "params": {
+                               "foo": "bar"
+                            }
+                        }]
+                    }
+                }))[methodName]('/example.com/nothing/else')
+                    .expect(200)
+                    .expect(function() {
+                        const hitUrl = new URL(fakeRequest.calls.argsFor(0)[0].url)                        
+                        expect(hitUrl.searchParams.get('foo')).toBeNull();
+                    })
+                    .end(assert(done));
+            });
+
+
+            it('no params appended when mismatch in regex', function(done) {
+                request(buildApp({
+                    proxyAllDomains: true,
+                    appendParamToQueryString: {
+                        "example.com": [{
+                            "regexPattern": "something",
+                            "params": {
+                               "foo": "bar"
+                            }
+                        }, {
+                           "regexPattern": "nothing",
+                            "params": {
+                               "yep": "works"
+                            }
+                        }
+                        ]
+                    }
+                }))[methodName]('/example.com/nothing/else')
+                    .expect(200)
+                    .expect(function() {
+                        const hitUrl = new URL(fakeRequest.calls.argsFor(0)[0].url)                        
+                        expect(hitUrl.searchParams.get('foo')).toBeNull();
+                        expect(hitUrl.searchParams.get('yep')).toBe('works');
+                    })
+                    .end(assert(done));
+            });
+
             it('append multiple params to the querystring for a specified domain', function(done) {
                 request(buildApp({
                     proxyAllDomains: true,
                     appendParamToQueryString: {
-                        "example.com": {
-                            "foo": "bar",
-                            "another": "val"
-                        }
+                        "example.com": [{
+                            "regexPattern": ".",
+                            "params": {
+                               "foo": "bar",
+                                "another": "val"
+                            }
+                        }]
                     }
                 }))[methodName]('/example.com')
                     .expect(200)
@@ -444,9 +518,12 @@ describe('proxy', function() {
                 request(buildApp({
                     proxyAllDomains: true,
                     appendParamToQueryString: {
-                        "example.com": {
-                            "foo": "bar"
-                        }
+                        "example.com": [{
+                            "regexPattern": ".",
+                            "params": {
+                               "foo": "bar"
+                            }
+                        }]
                     }
                 }))[methodName]('/example.com?already=here')
                     .expect(200)
@@ -461,9 +538,12 @@ describe('proxy', function() {
                 request(buildApp({
                     proxyAllDomains: true,
                     appendParamToQueryString: {
-                        "example.com": {
-                            "foo": "bar"
-                        }
+                        "example.com": [{
+                            "regexPattern": ".",
+                            "params": {
+                               "foo": "bar"
+                            }
+                        }]
                     }
                 }))[methodName]('/example2.com')
                     .expect(200)
@@ -473,7 +553,6 @@ describe('proxy', function() {
                     })
                     .end(assert(done));
             });
-
         });
     }
 


### PR DESCRIPTION
This PR enables you to attach additional parameters to a query string on a proxied url based on a domain name.

This is helpful if you need to append an api key that you don't want to display in the browser, and `Authorization` header is not available.

````
// serverconfig.json
{
    "appendParamToQueryString": {
        "somdomain.io": {
            "apikey": "1234"
        }
    }
}

Request to 
=> https://somedomain.io/whatever
becomes
=> https://somedomain.io/whatever?apikey=1234

````

