### PR TITLE
Added share max request option

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,3 +1,7 @@
+### Next version
+
+* Added option to configure post limit on `share` endpoint (see `shareMaxRequestSize` in `serverconfig.json.example`)
+
 ### 3.2.0
 
 * Support appending additional parameters to a querystring via the `/proxy` endpoint.

--- a/lib/controllers/share.js
+++ b/lib/controllers/share.js
@@ -137,7 +137,7 @@ function resolveS3(serviceOptions, id) {
 }
 
 
-module.exports = function(shareUrlPrefixes, newShareUrlPrefix, shareMaxPostSize, hostName, port) {
+module.exports = function(shareUrlPrefixes, newShareUrlPrefix, shareMaxRequestSize, hostName, port) {
     if (!shareUrlPrefixes) {
         return;
     }
@@ -145,7 +145,7 @@ module.exports = function(shareUrlPrefixes, newShareUrlPrefix, shareMaxPostSize,
     var router = require('express').Router();
     router.use(bodyParser.text({
         type: '*/*',
-        limit: shareMaxPostSize || '200kb'
+        limit: shareMaxRequestSize || '200kb'
     }));
 
     // Requested creation of a new short URL.

--- a/lib/controllers/share.js
+++ b/lib/controllers/share.js
@@ -137,7 +137,7 @@ function resolveS3(serviceOptions, id) {
 }
 
 
-module.exports = function(shareUrlPrefixes, newShareUrlPrefix, hostName, port) {
+module.exports = function(shareUrlPrefixes, newShareUrlPrefix, shareMaxPostSize, hostName, port) {
     if (!shareUrlPrefixes) {
         return;
     }
@@ -145,7 +145,7 @@ module.exports = function(shareUrlPrefixes, newShareUrlPrefix, hostName, port) {
     var router = require('express').Router();
     router.use(bodyParser.text({
         type: '*/*',
-        limit: '200kb'
+        limit: shareMaxPostSize || '200kb'
     }));
 
     // Requested creation of a new short URL.

--- a/lib/controllers/share.js
+++ b/lib/controllers/share.js
@@ -137,30 +137,30 @@ function resolveS3(serviceOptions, id) {
 }
 
 
-module.exports = function(shareUrlPrefixes, newShareUrlPrefix, shareMaxRequestSize, hostName, port) {
-    if (!shareUrlPrefixes) {
+module.exports = function(hostName, port, options) {
+    if (!options.shareUrlPrefixes) {
         return;
     }
 
     var router = require('express').Router();
     router.use(bodyParser.text({
         type: '*/*',
-        limit: shareMaxRequestSize || '200kb'
+        limit: options.shareMaxRequestSize || '200kb'
     }));
 
     // Requested creation of a new short URL.
     router.post('/', function(req, res, next) {
-        if (newShareUrlPrefix === undefined || !shareUrlPrefixes[newShareUrlPrefix]) {
+        if (options.newShareUrlPrefix === undefined || !options.shareUrlPrefixes[options.newShareUrlPrefix]) {
             return res.status(404).json({ message: "This server has not been configured to generate new share URLs." });
         }
-        var serviceOptions = shareUrlPrefixes[newShareUrlPrefix];
+        var serviceOptions = options.shareUrlPrefixes[options.newShareUrlPrefix];
         var minter = {
             'gist': makeGist,
             's3': saveS3
             }[serviceOptions.service.toLowerCase()];
 
         minter(serviceOptions, req.body).then(function(id) {
-            id = newShareUrlPrefix + prefixSeparator + id;
+            id = options.newShareUrlPrefix + prefixSeparator + id;
             var resPath = req.baseUrl + '/' + id;
             // these properties won't behave correctly unless "trustProxy: true" is set in user's options file.
             // they may not behave correctly (especially port) when behind multiple levels of proxy
@@ -188,7 +188,7 @@ module.exports = function(shareUrlPrefixes, newShareUrlPrefix, shareMaxRequestSi
         var id = req.params.id.match(splitPrefixRe)[3];
         var resolver;
 
-        var serviceOptions = shareUrlPrefixes[prefix];
+        var serviceOptions = options.shareUrlPrefixes[prefix];
         if (!serviceOptions) {
             console.error('Share: Unknown prefix to resolve "' + prefix + '", id "' + id + '"');
             return res.status(400).send('Unknown share prefix "' + prefix + '"');

--- a/lib/makeserver.js
+++ b/lib/makeserver.js
@@ -156,7 +156,7 @@ module.exports = function(options) {
     if (feedbackService) {
         endpoint('/feedback', feedbackService);
     }
-    var shareService = require('./controllers/share')(options.settings.shareUrlPrefixes, options.settings.newShareUrlPrefix, options.settings.shareMaxPostSize, options.hostName, options.port);
+    var shareService = require('./controllers/share')(options.settings.shareUrlPrefixes, options.settings.newShareUrlPrefix, options.settings.shareMaxRequestSize, options.hostName, options.port);
     if (shareService) {
         endpoint('/share', shareService);
     }

--- a/lib/makeserver.js
+++ b/lib/makeserver.js
@@ -156,7 +156,7 @@ module.exports = function(options) {
     if (feedbackService) {
         endpoint('/feedback', feedbackService);
     }
-    var shareService = require('./controllers/share')(options.settings.shareUrlPrefixes, options.settings.newShareUrlPrefix, options.hostName, options.port);
+    var shareService = require('./controllers/share')(options.settings.shareUrlPrefixes, options.settings.newShareUrlPrefix, options.settings.shareMaxPostSize, options.hostName, options.port);
     if (shareService) {
         endpoint('/share', shareService);
     }

--- a/lib/makeserver.js
+++ b/lib/makeserver.js
@@ -156,7 +156,15 @@ module.exports = function(options) {
     if (feedbackService) {
         endpoint('/feedback', feedbackService);
     }
-    var shareService = require('./controllers/share')(options.settings.shareUrlPrefixes, options.settings.newShareUrlPrefix, options.settings.shareMaxRequestSize, options.hostName, options.port);
+    var shareService = require("./controllers/share")(
+        options.hostName,
+        options.port,
+        {
+            shareUrlPrefixes: options.settings.shareUrlPrefixes,
+            newShareUrlPrefix: options.settings.newShareUrlPrefix,
+            shareMaxRequestSize: options.settings.shareMaxRequestSize
+        }
+    );
     if (shareService) {
         endpoint('/share', shareService);
     }

--- a/serverconfig.json.example
+++ b/serverconfig.json.example
@@ -165,7 +165,7 @@
     newShareUrlPrefix: "g",
 
     // The largest size, in bytes, of share JSON which can be received - can also be string, it defaults to '200kb'
-    shareMaxPostSize: "200kb",
+    shareMaxRequestSize: "200kb",
 
     // The domain at which you're running the server. Mostly used for describing the available endpoints. Defaults to "localhost"
     hostName: 'example.com',

--- a/serverconfig.json.example
+++ b/serverconfig.json.example
@@ -164,6 +164,9 @@
     // Which service (of those defined above) should be used when new URLs are requested.
     newShareUrlPrefix: "g",
 
+    // The largest size, in bytes, of share JSON which can be received - can also be string, it defaults to '200kb'
+    shareMaxPostSize: "200kb",
+
     // The domain at which you're running the server. Mostly used for describing the available endpoints. Defaults to "localhost"
     hostName: 'example.com',
 


### PR DESCRIPTION
I was getting `PayloadTooLargeError: request entity too large` due to the create share link request payload being > 200kb (the previous hard coded default).

So I added a `shareMaxRequestSize` server option!