### PR TITLE
Fix server crash when remote host returns a redirect url with no hostname

### DIFF
--- a/lib/controllers/proxy.js
+++ b/lib/controllers/proxy.js
@@ -253,7 +253,9 @@ module.exports = function(options) {
                             var location = response.headers.location;
                             if (location && location.length > 0) {
                                 var parsed = url.parse(location);
-                                if (proxyAllowedHost(parsed.host)) {
+                                // location header can be a relative URL with no host name. In that case, we default to the remote url host.
+                                var redirectHost = typeof parsed.host === "string" ? parsed.host :  remoteUrl.host;
+                                if (proxyAllowedHost(redirectHost)) {
                                     // redirect is ok
                                     return true;
                                 }


### PR DESCRIPTION
This PR fixes a bug where the server throws an error if the remote host returns a 30x response with a location header containing a relative URL with no hostname. In that case we default to the remoteUrl host.