### PR TITLE
jasmine.json: remove helpers section

### DIFF
--- a/spec/support/jasmine.json
+++ b/spec/support/jasmine.json
@@ -3,9 +3,6 @@
   "spec_files": [
     "**/*[sS]pec.js"
   ],
-  "helpers": [
-    "helpers/**/*.js"
-  ],
   "stopSpecOnExpectationFailure": false,
   "random": false
 }


### PR DESCRIPTION
There are no jasmine helpers,
so remove the config for them
to remove a:

Message:
  Uncaught exception: Error: ENOENT: no such file or directory, scandir '/app/spec/helpers'
Stack:
  error properties: Object({ errno: -2, code: 'ENOENT', syscall: 'scandir', path: '/app/spec/helpers' })
  Error: ENOENT: no such file or directory, scandir '/app/spec/helpers'
      at Object.readdirSync (node:fs:1508:26)

error from the tests.