### PR TITLE
Replace express-brute

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,6 +1,7 @@
 ### Next version
 
 * Require Node 20.
+* Replace express-brute with rate-limiter-flexible (fixes GHSA-984p-xq9m-4rjw).
 
 ### 4.0.1
 

--- a/lib/makeserver.js
+++ b/lib/makeserver.js
@@ -8,7 +8,7 @@ var cors = require('cors');
 var exists = require('./exists');
 var basicAuth = require('basic-auth');
 var fs = require('fs');
-var ExpressBrute = require('express-brute');
+const ExpressBruteFlexible = require('rate-limiter-flexible/lib/ExpressBruteFlexible');
 
 /* Creates and returns a single express server. */
 module.exports = function(options) {
@@ -75,7 +75,6 @@ module.exports = function(options) {
 
     var auth = options.settings.basicAuthentication;
     if (auth && auth.username && auth.password) {
-        var store = new ExpressBrute.MemoryStore();
         var rateLimitOptions = {
             freeRetries: 2,
             minWait: 200,
@@ -86,7 +85,10 @@ module.exports = function(options) {
             rateLimitOptions.minWait = options.settings.rateLimit.minWait;
             rateLimitOptions.maxWait = options.settings.rateLimit.maxWait;
         }
-        var bruteforce = new ExpressBrute(store, rateLimitOptions);
+        const bruteforce = new ExpressBruteFlexible(
+            ExpressBruteFlexible.LIMITER_TYPES.MEMORY,
+            rateLimitOptions
+        );
         app.use(bruteforce.prevent, function(req, res, next) {
             var user = basicAuth(req);
             if (user && user.name === auth.username && user.pass === auth.password) {

--- a/package.json
+++ b/package.json
@@ -6,9 +6,6 @@
   "engines": {
     "node": ">=20.0.0"
   },
-  "resolutions": {
-    "underscore": "^1.12.1"
-  },
   "main": "lib/app.js",
   "scripts": {
     "test": "jasmine",
@@ -39,12 +36,12 @@
     "compression": "^1.6.0",
     "cors": "^2.7.1",
     "express": "^4.21.2",
-    "express-brute": "^1.0.1",
     "json5": "^2.2.3",
     "morgan": "^1.7.0",
     "proj4": "^2.3.12",
     "proj4js-defs": "0.0.1",
     "range_check": "^1.4.0",
+    "rate-limiter-flexible": "^5.0.3",
     "request": "^2.88.2",
     "request-promise": "^4.0.1",
     "yargs": "^13.2.4"

--- a/yarn.lock
+++ b/yarn.lock
@@ -462,14 +462,6 @@ events@1.1.1:
   resolved "https://registry.yarnpkg.com/events/-/events-1.1.1.tgz#9ebdb7635ad099c70dcc4c2a1f5004288e8bd924"
   integrity sha512-kEcvvCBByWXGnZy6JUlgAp2gBIUjfCAV6P6TgT1/aaQKcmuAEC4OZTV1I4EWQLz2gxZw76atuVyvHhTxvi0Flw==
 
-express-brute@^1.0.1:
-  version "1.0.1"
-  resolved "https://registry.yarnpkg.com/express-brute/-/express-brute-1.0.1.tgz#9f36d107fe34e40a682593e39bffcc53102b5335"
-  integrity sha512-ieZmwox3oIZdQCVjvvnwQvrKQumWdb/JjmC9mWplF42AuHCBXr6Yk/I+nLTRQx+9F+2aapOW9kYLwA6xIlwA9g==
-  dependencies:
-    long-timeout "~0.1.1"
-    underscore "~1.8.3"
-
 express@^4.21.2:
   version "4.21.2"
   resolved "https://registry.yarnpkg.com/express/-/express-4.21.2.tgz#cf250e48362174ead6cea4a566abef0162c1ec32"
@@ -915,11 +907,6 @@ lodash@^4.17.19:
   resolved "https://registry.yarnpkg.com/lodash/-/lodash-4.17.21.tgz#679591c564c3bffaae8454cf0b3df370c3d6911c"
   integrity sha512-v2kDEe57lecTulaDIuNTPy3Ry4gLGJ6Z1O3vE1krgXZNrsQ+LFTGHVxVjcXPs17LhbZVGedAJv8XZ1tvj5FvSg==
 
-long-timeout@~0.1.1:
-  version "0.1.1"
-  resolved "https://registry.yarnpkg.com/long-timeout/-/long-timeout-0.1.1.tgz#9721d788b47e0bcb5a24c2e2bee1a0da55dab514"
-  integrity sha512-BFRuQUqc7x2NWxfJBCyUrN8iYUYznzL9JROmRz1gZ6KlOIgmoD+njPVbb+VNn2nGMKggMsK79iUNErillsrx7w==
-
 math-intrinsics@^1.1.0:
   version "1.1.0"
   resolved "https://registry.yarnpkg.com/math-intrinsics/-/math-intrinsics-1.1.0.tgz#a0dd74be81e2aa5c2f27e65ce283605ee4e2b7f9"
@@ -1174,6 +1161,11 @@ range_check@^1.4.0:
   dependencies:
     ip6 "0.0.4"
     ipaddr.js "1.2"
+
+rate-limiter-flexible@^5.0.3:
+  version "5.0.5"
+  resolved "https://registry.yarnpkg.com/rate-limiter-flexible/-/rate-limiter-flexible-5.0.5.tgz#4b7df3cbda7e589704b333be0703d5f159f769d5"
+  integrity sha512-+/dSQfo+3FYwYygUs/V2BBdwGa9nFtakDwKt4l0bnvNB53TNT++QSFewwHX9qXrZJuMe9j+TUaU21lm5ARgqdQ==
 
 raw-body@2.5.2:
   version "2.5.2"
@@ -1460,11 +1452,6 @@ type-is@~1.6.18:
   dependencies:
     media-typer "0.3.0"
     mime-types "~2.1.24"
-
-underscore@^1.12.1, underscore@~1.8.3:
-  version "1.13.6"
-  resolved "https://registry.yarnpkg.com/underscore/-/underscore-1.13.6.tgz#04786a1f589dc6c09f761fc5f45b89e935136441"
-  integrity sha512-+A5Sja4HP1M08MaXya7p5LvjuM7K6q/2EaC0+iovj/wOcMsTzMvDFbasi/oSapiwOlt252IqsKqPjCl7huKS0A==
 
 unpipe@1.0.0, unpipe@~1.0.0:
   version "1.0.0"


### PR DESCRIPTION
This replaces express-brute with
rate-limiter-flexible, which
removes the dependency on the vulnerable
underscore version, and does not have
a rate limit bypass vulnerability.