### PR TITLE
Fix proxy POST

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -18,7 +18,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        node-version: [18.x, 20.x, 21.x]
+        node-version: [16.x, 18.x, 20.x, 22.x]
 
     steps:
     - uses: actions/checkout@v4

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,10 +1,6 @@
 name: CI
 
-on:
-  push:
-    branches: [ "master" ]
-  pull_request:
-    branches: [ "master" ]
+on: [push, pull_request]
 
 # When a PR is updated, cancel the jobs from the previous version. Merges
 # do not define head_ref, so use run_id to never cancel those jobs.

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,5 +1,9 @@
 ### Next version
 
+### 4.0.1
+
+* Fixed proxied upstream POST request being aborted when the stream associated with the downstream request is closed on Node v16+. This will now again correctly be triggered only when the socket is closed early.
+
 ### 4.0.0
 
 * Removed conversion service (no longer used in TerriaJS 8+).

--- a/lib/controllers/proxy.js
+++ b/lib/controllers/proxy.js
@@ -198,8 +198,8 @@ module.exports = function(options) {
         // encoding : null means "body" passed to the callback will be raw bytes
 
         var proxiedRequest;
-        req.on('close', function() {
-            if (proxiedRequest) {
+        req.socket.once('close', function() {
+            if (proxiedRequest && !res.writableEnded) {
                 proxiedRequest.abort();
             }
         });

--- a/lib/controllers/proxy.js
+++ b/lib/controllers/proxy.js
@@ -198,7 +198,7 @@ module.exports = function(options) {
         // encoding : null means "body" passed to the callback will be raw bytes
 
         var proxiedRequest;
-        req.socket.once('close', function() {
+        res.once('close', function() {
             if (proxiedRequest && !res.writableEnded) {
                 proxiedRequest.abort();
             }

--- a/spec/proxy.spec.js
+++ b/spec/proxy.spec.js
@@ -228,7 +228,7 @@ describe('proxy', function() {
                 request(buildApp(openProxyOptions))
                       [methodName]('/_2h/example.com')
                       .set('Cache-Control', 'no-cache')
-                      .set('x-give-response-status', '500')
+                      .set('x-give-response-status', 500)
                       .expect(500)
                       .expect('cache-control', 'no-cache')
                       .end(assert(done));


### PR DESCRIPTION
- **Fix upstream proxied POST request being aborted early on Node 16+**
- **Include node 16 in tests**
- **Fix warning**


Node 16 changed when the "close" event of IncomingMessage `req` is fired. This used to be fired when the socket was closed before the request finished. Now, to better match the ReadableStream interface, it is fired when the stream representing the downstream request (from TerriaMap) closes - i.e. when the entire request has been parsed by node.js - so this event is now fired for every request and in most cases before the proxied request has finished. Since our proxy controller aborts the upstream request on this event, that means that our proxy controller is now trying to abort every upstream request. This seems to only affect POST requests, but it's possible it could affect GET requests in certain cases.

The fix included here is to rather use the "close" event of the ServerResonse `res`. This stream will be closed after a successfully finished response, or if the socket is closed.