### PR TITLE
Adding S3 Endpoint Config Option

### DIFF
--- a/lib/controllers/share.js
+++ b/lib/controllers/share.js
@@ -83,7 +83,8 @@ function S3(serviceOptions) {
     } else {
         var aws = require('aws-sdk');
         aws.config.update({
-            region: serviceOptions.region
+          endpoint: serviceOptions.endpoint ? serviceOptions.endpoint : undefined,
+          region: serviceOptions.region
         });
         // if no credentials provided, we assume that they're being provided as environment variables or in a file
         if (serviceOptions.accessKeyId) {

--- a/lib/controllers/share.js
+++ b/lib/controllers/share.js
@@ -83,7 +83,7 @@ function S3(serviceOptions) {
     } else {
         var aws = require('aws-sdk');
         aws.config.update({
-          endpoint: serviceOptions.endpoint ? serviceOptions.endpoint : undefined,
+          endpoint: serviceOptions.endpoint ?? undefined,
           region: serviceOptions.region
         });
         // if no credentials provided, we assume that they're being provided as environment variables or in a file

--- a/lib/controllers/share.js
+++ b/lib/controllers/share.js
@@ -83,8 +83,8 @@ function S3(serviceOptions) {
     } else {
         var aws = require('aws-sdk');
         aws.config.update({
-          endpoint: serviceOptions.endpoint ?? undefined,
-          region: serviceOptions.region
+            endpoint: serviceOptions.endpoint ?? undefined,
+            region: serviceOptions.region
         });
         // if no credentials provided, we assume that they're being provided as environment variables or in a file
         if (serviceOptions.accessKeyId) {

--- a/serverconfig.json.example
+++ b/serverconfig.json.example
@@ -142,7 +142,7 @@
             "bucket": "terria-sharedata"
 
             // Optional: pass through custom S3 endpoint which will utilise the above region.
-            "endpoint": "https://{region}.your.custom.s3.endpoint.com
+            "endpoint": "https://{region}.your.custom.s3.endpoint.com",
 
             // Optional: The access key ID and secret access key of a user with S3 getObject and putObject permission on the above bucket
             // If not provided here, you must ensure they're available as environment variables or in a shared credentials file.

--- a/serverconfig.json.example
+++ b/serverconfig.json.example
@@ -141,6 +141,9 @@
             // Required: an existing S3 bucket in which to store objects
             "bucket": "terria-sharedata"
 
+            // Optional: pass through custom S3 endpoint which will utilise the above region.
+            "endpoint": "https://{region}.your.custom.s3.endpoint.com
+
             // Optional: The access key ID and secret access key of a user with S3 getObject and putObject permission on the above bucket
             // If not provided here, you must ensure they're available as environment variables or in a shared credentials file.
             // See http://docs.aws.amazon.com/AWSJavaScriptSDK/guide/node-configuring.html


### PR DESCRIPTION
Allows for custom S3 endpoints to be added to the server config.

This pull request includes updates to the S3 configuration in the `lib/controllers/share.js` file and the `serverconfig.json.example` file to support custom S3 endpoints. These changes enhance the flexibility of the S3 service configuration.

Configuration updates:

* [`lib/controllers/share.js`](diffhunk://#diff-25280ebd6726f4002498beb49d25bc2058d4ec6df779ffcc7a75bd26d14929cbR86): Added support for a custom S3 endpoint by updating the AWS configuration to include the `endpoint` option if provided in `serviceOptions`.
* [`serverconfig.json.example`](diffhunk://#diff-8f1a24d2bd2d8e4f22f388463d88186fbe7f6080b168f1ecf9da6914b77538d9R144-R146): Added an optional `endpoint` field to allow users to specify a custom S3 endpoint in the configuration file.