### PR TITLE
Upgrade base-x to 5.x+.

### DIFF
--- a/lib/controllers/share.js
+++ b/lib/controllers/share.js
@@ -70,7 +70,7 @@ function resolveGist(serviceOptions, id) {
  */
 function shortId(body, length) {
     var hmac = require('crypto').createHmac('sha1', body).digest();
-    var base62 = require("base-x")('0123456789abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ');
+    var base62 = require("base-x").default('0123456789abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ');
     var fullkey = base62.encode(hmac);
     return fullkey.slice(0, length); // if length undefined, return the whole thing
 }

--- a/package.json
+++ b/package.json
@@ -33,7 +33,7 @@
   "homepage": "https://github.com/TerriaJS/TerriaJS-Server",
   "dependencies": {
     "aws-sdk": "^2.1336.0",
-    "base-x": "^3.0.5",
+    "base-x": "^5.0.1",
     "basic-auth": "^2.0.1",
     "body-parser": "^1.20.3",
     "compression": "^1.6.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -109,12 +109,10 @@ balanced-match@^1.0.0:
   resolved "https://registry.yarnpkg.com/balanced-match/-/balanced-match-1.0.2.tgz#e83e3a7e3f300b34cb9d87f615fa0cbf357690ee"
   integrity sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw==
 
-base-x@^3.0.5:
-  version "3.0.9"
-  resolved "https://registry.yarnpkg.com/base-x/-/base-x-3.0.9.tgz#6349aaabb58526332de9f60995e548a53fe21320"
-  integrity sha512-H7JU6iBHTal1gp56aKoaa//YUxEaAOUiydvrV/pILqIHXTtqxSkATOnDA2u+jZ/61sD+L/412+7kzXRtWukhpQ==
-  dependencies:
-    safe-buffer "^5.0.1"
+base-x@^5.0.1:
+  version "5.0.1"
+  resolved "https://registry.yarnpkg.com/base-x/-/base-x-5.0.1.tgz#16bf35254be1df8aca15e36b7c1dda74b2aa6b03"
+  integrity sha512-M7uio8Zt++eg3jPj+rHMfCC+IuygQHHCOU+IYsVtik6FWjuYpVt/+MRKcgsAMHh8mMFAwnB+Bs+mTrFiXjMzKg==
 
 base64-js@^1.0.2:
   version "1.5.1"


### PR DESCRIPTION
Addresses CVE (although it doesn't affect our usage) - https://github.com/TerriaJS/terriajs-server/security/dependabot/57