### PR TITLE
Fix specs for node-rate-limiter.

### DIFF
--- a/spec/ratelimit.spec.js
+++ b/spec/ratelimit.spec.js
@@ -81,7 +81,7 @@ describe("server rate limiting", function () {
 
       for (let attempt = 0; attempt < 10; attempt++) {
         const { res } = await makeRequest(app, "/pingauth");
-        if (attempt <= rateLimit.freeRetries) {
+        if (attempt < rateLimit.freeRetries) {
           if (res.status !== 401) {
             throw new Error(
               `Expected only HTTP 401 error before free retries finish`


### PR DESCRIPTION
Accounts for difference in how node-rate-limiter and express-brute tests limit.