### PR TITLE
Release version to 4.0.2.

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,7 +1,10 @@
 ### Next version
 
-* Require Node 20.
+### 4.0.2 - 2025-06-03
+
+* Requires Node 20.
 * Replace express-brute with rate-limiter-flexible (fixes GHSA-984p-xq9m-4rjw).
+* Upgraded bunch of dependencies: body-parser, express, supertest, base-x, proj4 etc.
 
 ### 4.0.1
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "terriajs-server",
-  "version": "4.0.1",
+  "version": "4.0.2",
   "description": "NodeJS server for TerriaJS, consisting of a CORS proxy, proj4 CRS lookup service, and express static server.",
   "engineStrict": true,
   "engines": {


### PR DESCRIPTION
CHANGES:

* Requires Node 20.
* Replace express-brute with rate-limiter-flexible (fixes GHSA-984p-xq9m-4rjw).
* Upgraded bunch of dependencies: body-parser, express, supertest, base-x, proj4 etc.