### PR TITLE
Restore the previous behaviour when parsing positional arguments with Yargs

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,5 +1,7 @@
 ### Next version
 
+* Restored the previous behaviour changed after yargs upgrade. Fixed #194.
+
 ### 4.0.2 - 2025-06-03
 
 * Requires Node 20.

--- a/lib/options.js
+++ b/lib/options.js
@@ -54,7 +54,8 @@ function getConfig(filePath, configFileType, failureConsequence, quiet) {
 function loadCommandLine() {
     var yargs = require('yargs')
         .parserConfiguration({
-        "duplicate-arguments-array": false
+            "halt-at-non-option": true,
+            "duplicate-arguments-array": false
          })
         .usage('$0 [options] [path/to/wwwroot]')
         .strict()


### PR DESCRIPTION
Fixes https://github.com/TerriaJS/terriajs-server/issues/194

Now the arguments are passed correctly with either
```sh
node lib/app.js --port=4000 /some/path/to/wwwroot 
```
or, in a new fashion,
```
node lib/app.js --port=4000 -- /some/path/to/wwwroot
```