### PR TITLE
Strip Cookie and Authorization headers when proxying.

### DIFF
--- a/lib/controllers/proxy.js
+++ b/lib/controllers/proxy.js
@@ -7,7 +7,7 @@ var url = require('url');
 var bodyParser = require('body-parser');
 var rangeCheck = require('range_check');
 
-var DO_NOT_PROXY_REGEX = /^(?:Host|X-Forwarded-Host|Proxy-Connection|Connection|Keep-Alive|Transfer-Encoding|TE|Trailer|Proxy-Authorization|Proxy-Authenticate|Upgrade|Expires|pragma|Strict-Transport-Security)$/i;
+var DO_NOT_PROXY_REGEX = /^(?:Host|X-Forwarded-Host|Proxy-Connection|Connection|Keep-Alive|Transfer-Encoding|TE|Trailer|Proxy-Authorization|Proxy-Authenticate|Upgrade|Expires|pragma|Strict-Transport-Security|Cookie|Authorization)$/i;
 var PROTOCOL_REGEX = /^\w+:\//;
 var DURATION_REGEX = /^([\d.]+)(ms|s|m|h|d|w|y)$/;
 var DURATION_UNITS = {

--- a/spec/proxy.spec.js
+++ b/spec/proxy.spec.js
@@ -107,11 +107,16 @@ describe('proxy', function() {
                 request(buildApp(openProxyOptions))
                     [methodName]('/example.com')
                     .set('Proxy-Connection', 'delete me!')
+                    .set('Cookie', 'delete me!')
+                    .set('Authorization', 'delete me!')                                
                     .set('unfilteredheader', 'don\'t delete me!')
                     .expect(200)
                     .expect(function() {
-                        expect(fakeRequest.calls.argsFor(0)[0].headers['Proxy-Connection']).toBeUndefined();
-                        expect(fakeRequest.calls.argsFor(0)[0].headers['unfilteredheader']).toBe('don\'t delete me!');
+                        const headers = fakeRequest.calls.argsFor(0)[0].headers;
+                        expect(headers['Proxy-Connection']).toBeUndefined();
+                        expect(headers['Cookie']).toBeUndefined();
+                        expect(headers['Authorization']).toBeUndefined();                        
+                        expect(headers['unfilteredheader']).toBe('don\'t delete me!');
                     })
                     .end(assert(done));
             });


### PR DESCRIPTION
Make sure proxy strips `Cookie` and `Authorization` headers when proxying.