### PR TITLE
fix: stop returning incorrect location for created share url

### DIFF
--- a/lib/controllers/share.js
+++ b/lib/controllers/share.js
@@ -168,7 +168,7 @@ async function resolveS3(serviceOptions, id) {
   }
 }
 
-export default function (_hostName, port, options) {
+export default function (options) {
   if (!options.shareUrlPrefixes) {
     return;
   }
@@ -214,14 +214,7 @@ export default function (_hostName, port, options) {
           ? id
           : options.newShareUrlPrefix + prefixSeparator + id;
 
-      const resPath = `${req.baseUrl}/${shareId}`;
-      // these properties won't behave correctly unless "trustProxy: true" is set in user's options file.
-      // they may not behave correctly (especially port) when behind multiple levels of proxy
-      const resUrl = `${req.protocol}://${req.hostname}${req.header("X-Forwarded-Port") || port}${resPath}`;
-      res
-        .location(resUrl)
-        .status(201)
-        .json({ id: shareId, path: resPath, url: resUrl });
+      res.status(201).json({ id: shareId });
     } catch (reason) {
       console.error(JSON.stringify(reason, null, 2));
       const errorMessage =

--- a/lib/makeserver.js
+++ b/lib/makeserver.js
@@ -192,7 +192,7 @@ export default function (options) {
   if (feedbackService) {
     endpoint("/feedback", feedbackService);
   }
-  const shareService = share(options.hostName, options.port, {
+  const shareService = share({
     shareUrlPrefixes: options.settings.shareUrlPrefixes,
     newShareUrlPrefix: options.settings.newShareUrlPrefix,
     shareMaxRequestSize: options.settings.shareMaxRequestSize

--- a/spec/share-s3.spec.js
+++ b/spec/share-s3.spec.js
@@ -99,8 +99,8 @@ describe("Share Module (e2e) - S3", () => {
       .send({ data: "test content empty" })
       .expect(201);
 
-    expect(response.body.url).toBeDefined();
-    expect(response.body.url).toContain("/share/hBp74ADLrPU6flu0qu07Kyi1FM0");
+    expect(response.body.id).toBeDefined();
+    expect(response.body.id).toEqual("hBp74ADLrPU6flu0qu07Kyi1FM0");
 
     await supertestReq(app)
       .get("/share/hBp74ADLrPU6flu0qu07Kyi1FM0")

--- a/spec/share.spec.js
+++ b/spec/share.spec.js
@@ -69,11 +69,7 @@ describe("share endpoint (integration, real controller)", () => {
         .expect(201)
         .expect("Content-Type", /json/)
         .expect((res) => {
-          const actualUrl = res.body.url;
-          const expectedPath = `/share/g-${fakeGistId}`;
           expect(res.body.id).toBe(`g-${fakeGistId}`);
-          expect(res.body.path).toBe(expectedPath);
-          expect(actualUrl.endsWith(expectedPath)).toBeTrue();
         });
     });
 


### PR DESCRIPTION
The URL path for share url location is built incorrectly if the app is served on the subpath, i.e. generating the share URL on http://ci.terria.io/main will respond with URL http://ci.terria.io80/share/s-s0AWONpTwc5i6vpuSqlJVmJIXzA and path /share/s-s0AWONpTwc5i6vpuSqlJVmJIXzA, but the URL should be [http://ci.terria.io:80/main/share/s-s0AWONpTwc5i6vpuSqlJVmJIXzA](http://ci.terria.io/main/share/s-s0AWONpTwc5i6vpuSqlJVmJIXzA). You can see that it incorrectly concatenates the port and misses the basePath. PR https://github.com/TerriaJS/terriajs-server/pull/330 solves the concatenation issues, but doesn't solve the missing basePath issue, and we never used the url or path from response, so it's safer to remove it from the response than to introduce more configuration properties to be able to specify the path or rely on non-standard `X-Forwarded-Prefix`