### PR TITLE
fix: prevent proxy cache poisoning on authenticated responses

### DIFF
--- a/lib/controllers/proxy.js
+++ b/lib/controllers/proxy.js
@@ -137,7 +137,7 @@ export default function (options) {
         host: remoteUrl.host
       });
 
-      const response = await executeWithRetry({
+      const { response, usedAuthStrategy } = await executeWithRetry({
         strategies: authStrategies,
         requestOptions: {
           headers: filteredReqHeaders
@@ -152,9 +152,10 @@ export default function (options) {
           })
       });
       const { statusCode, headers, body } = response;
+      const isAuthenticated = usedAuthStrategy.type !== "none";
 
       // Handle success responses
-      res.set(processHeaders(headers, maxAgeSeconds));
+      res.set(processHeaders(headers, maxAgeSeconds, isAuthenticated));
       res.status(statusCode);
 
       const sizeLimiter = createSizeLimiter(responseSizeLimit);

--- a/lib/controllers/proxy.js
+++ b/lib/controllers/proxy.js
@@ -152,10 +152,14 @@ export default function (options) {
           })
       });
       const { statusCode, headers, body } = response;
-      const isAuthenticated = usedAuthStrategy.type !== "none";
 
       // Handle success responses
-      res.set(processHeaders(headers, maxAgeSeconds, isAuthenticated));
+      res.set(
+        processHeaders(headers, maxAgeSeconds, {
+          isAuthenticated: usedAuthStrategy.type !== "none",
+          varyByAuthorization: usedAuthStrategy.type === "user"
+        })
+      );
       res.status(statusCode);
 
       const sizeLimiter = createSizeLimiter(responseSizeLimit);

--- a/lib/controllers/proxy/execute-with-retry.js
+++ b/lib/controllers/proxy/execute-with-retry.js
@@ -24,10 +24,8 @@ async function executeWithRetry({ strategies, requestOptions, fetchFn }) {
 
     const headers = buildRequestHeaders(requestOptions.headers, strategy);
     try {
-      const response = await fetchFn({
-        headers
-      });
-      return response;
+      const response = await fetchFn({ headers });
+      return { response, usedAuthStrategy: strategy };
     } catch (err) {
       const shouldRetry =
         AUTH_STATUS_CODES.includes(err.statusCode) && !isLastStrategy;

--- a/lib/controllers/proxy/process-headers.js
+++ b/lib/controllers/proxy/process-headers.js
@@ -8,11 +8,16 @@ import { filterHeaders } from "./filter-headers.js";
  *          specified because we know better than they do.
  * @returns {Record<string, unknown>} The new headers object.
  */
-function processHeaders(headers, maxAgeSeconds) {
+function processHeaders(headers, maxAgeSeconds, isAuthenticated = false) {
   const result = filterHeaders(headers, undefined);
 
   if (maxAgeSeconds !== undefined) {
-    result["cache-control"] = `public,max-age=${maxAgeSeconds}`;
+    const visibility = isAuthenticated ? "private" : "public";
+    result["cache-control"] = `${visibility},max-age=${maxAgeSeconds}`;
+  }
+
+  if (isAuthenticated) {
+    result["vary"] = "Authorization";
   }
 
   result["access-control-allow-origin"] = "*";

--- a/lib/controllers/proxy/process-headers.js
+++ b/lib/controllers/proxy/process-headers.js
@@ -8,7 +8,11 @@ import { filterHeaders } from "./filter-headers.js";
  *          specified because we know better than they do.
  * @returns {Record<string, unknown>} The new headers object.
  */
-function processHeaders(headers, maxAgeSeconds, isAuthenticated = false) {
+function processHeaders(
+  headers,
+  maxAgeSeconds,
+  { isAuthenticated = false, varyByAuthorization = false } = {}
+) {
   const result = filterHeaders(headers, undefined);
 
   if (maxAgeSeconds !== undefined) {
@@ -16,7 +20,7 @@ function processHeaders(headers, maxAgeSeconds, isAuthenticated = false) {
     result["cache-control"] = `${visibility},max-age=${maxAgeSeconds}`;
   }
 
-  if (isAuthenticated) {
+  if (varyByAuthorization) {
     result["vary"] = "Authorization";
   }
 

--- a/spec/controllers/proxy/execute-with-retry.spec.js
+++ b/spec/controllers/proxy/execute-with-retry.spec.js
@@ -22,7 +22,11 @@ describe("executeWithRetry", () => {
       fetchFn: mockFetch
     });
 
-    expect(result.statusCode).toBe(200);
+    expect(result.response.statusCode).toBe(200);
+    expect(result.usedAuthStrategy).toEqual({
+      type: "user",
+      authorization: "Bearer token"
+    });
     expect(mockFetch).toHaveBeenCalledWith({
       headers: {
         authorization: "Bearer token"
@@ -55,7 +59,11 @@ describe("executeWithRetry", () => {
       fetchFn: mockFetch
     });
 
-    expect(result.statusCode).toBe(200);
+    expect(result.response.statusCode).toBe(200);
+    expect(result.usedAuthStrategy).toEqual({
+      type: "proxy",
+      authorization: "Bearer correct"
+    });
     expect(mockFetch).toHaveBeenCalledTimes(2);
     expect(mockFetch.calls.argsFor(0)).toEqual([
       { headers: { authorization: "Bearer wrong" } }
@@ -95,7 +103,8 @@ describe("executeWithRetry", () => {
       fetchFn: mockFetch
     });
 
-    expect(result.statusCode).toBe(200);
+    expect(result.response.statusCode).toBe(200);
+    expect(result.usedAuthStrategy).toEqual({ type: "none" });
 
     expect(mockFetch.calls.argsFor(0)).toEqual([
       { headers: { authorization: "Bearer wrong" } }

--- a/spec/controllers/proxy/process-headers.spec.js
+++ b/spec/controllers/proxy/process-headers.spec.js
@@ -39,14 +39,25 @@ describe("proxy processHeaders", () => {
   });
 
   describe("cache poisoning prevention", () => {
-    it("uses private cache-control when request is authenticated", () => {
+    it("uses private cache-control and Vary: Authorization when client auth was used", () => {
       const result = processHeaders(
         { "content-type": "application/json" },
+
         1200,
-        true
+        { isAuthenticated: true, varyByAuthorization: true }
       );
       expect(result["cache-control"]).toBe("private,max-age=1200");
       expect(result["vary"]).toBe("Authorization");
+    });
+
+    it("uses private cache-control without Vary when server-configured auth was used", () => {
+      const result = processHeaders(
+        { "content-type": "application/json" },
+        1200,
+        { isAuthenticated: true, varyByAuthorization: false }
+      );
+      expect(result["cache-control"]).toBe("private,max-age=1200");
+      expect(result["vary"]).toBeUndefined();
     });
 
     it("uses public cache-control and no Vary when request is not authenticated", () => {

--- a/spec/controllers/proxy/process-headers.spec.js
+++ b/spec/controllers/proxy/process-headers.spec.js
@@ -37,4 +37,35 @@ describe("proxy processHeaders", () => {
     expect(result["cache-control"]).toBeUndefined();
     expect(result["access-control-allow-origin"]).toBe("*");
   });
+
+  describe("cache poisoning prevention", () => {
+    it("uses private cache-control when request is authenticated", () => {
+      const result = processHeaders(
+        { "content-type": "application/json" },
+        1200,
+        true
+      );
+      expect(result["cache-control"]).toBe("private,max-age=1200");
+      expect(result["vary"]).toBe("Authorization");
+    });
+
+    it("uses public cache-control and no Vary when request is not authenticated", () => {
+      const result = processHeaders(
+        { "content-type": "application/json" },
+        1200,
+        false
+      );
+      expect(result["cache-control"]).toBe("public,max-age=1200");
+      expect(result["vary"]).toBeUndefined();
+    });
+
+    it("defaults to public cache-control and no Vary when isAuthenticated is omitted", () => {
+      const result = processHeaders(
+        { "content-type": "application/json" },
+        1200
+      );
+      expect(result["cache-control"]).toBe("public,max-age=1200");
+      expect(result["vary"]).toBeUndefined();
+    });
+  });
 });

--- a/spec/proxy.e2e.spec.js
+++ b/spec/proxy.e2e.spec.js
@@ -870,7 +870,9 @@ function doCommonTest(methodName) {
           [methodName](`/proxy/localhost:${TEST_SERVER_PORT}/cache-proxy-auth`)
           .expect(200)
           .expect("Cache-Control", "private,max-age=1209600");
-        expect(proxyAuthRes.headers["vary"]).toContain("Authorization");
+        expect(proxyAuthRes.headers["vary"] ?? "").not.toContain(
+          "Authorization"
+        );
       });
 
       it("uses public cache-control and no Vary: Authorization when user auth fails and none strategy succeeds", async () => {

--- a/spec/proxy.e2e.spec.js
+++ b/spec/proxy.e2e.spec.js
@@ -824,6 +824,99 @@ function doCommonTest(methodName) {
         .expect(403, { statusCode: 403, message: "No Auth Also Failed" });
     });
 
+    describe("cache-control visibility based on which auth strategy succeeded", () => {
+      it("uses private cache-control and Vary: Authorization when user auth succeeds", async () => {
+        testServer.addRoute(methodName, "/cache-user-auth", (req, res) => {
+          if (req.headers.authorization !== "Bearer user-token") {
+            return res.status(401).json({ error: "Unauthorized" });
+          }
+          res.status(200).json({ data: "protected" });
+        });
+
+        const { app } = await buildApp({
+          proxyAllDomains: true,
+          blacklistedAddresses: ["202.168.1.1"]
+        });
+
+        const userAuthRes = await supertestReq(app)
+          [methodName](`/proxy/localhost:${TEST_SERVER_PORT}/cache-user-auth`)
+          .set("Authorization", "Bearer user-token")
+          .expect(200)
+          .expect("Cache-Control", "private,max-age=1209600");
+        expect(userAuthRes.headers["vary"]).toContain("Authorization");
+      });
+
+      it("uses private cache-control and Vary: Authorization when proxy auth succeeds", async () => {
+        testServer.addRoute(methodName, "/cache-proxy-auth", (req, res) => {
+          if (req.headers.authorization !== "server-token") {
+            return res.status(401).json({ error: "Unauthorized" });
+          }
+          res.status(200).json({ data: "protected" });
+        });
+
+        const { app } = await buildApp(
+          {
+            proxyAllDomains: true,
+            blacklistedAddresses: ["202.168.1.1"]
+          },
+          {
+            [`localhost:${TEST_SERVER_PORT}`]: {
+              authorization: "server-token"
+            }
+          }
+        );
+
+        const proxyAuthRes = await supertestReq(app)
+          [methodName](`/proxy/localhost:${TEST_SERVER_PORT}/cache-proxy-auth`)
+          .expect(200)
+          .expect("Cache-Control", "private,max-age=1209600");
+        expect(proxyAuthRes.headers["vary"]).toContain("Authorization");
+      });
+
+      it("uses public cache-control and no Vary: Authorization when user auth fails and none strategy succeeds", async () => {
+        let attempt = 0;
+        testServer.addRoute(methodName, "/cache-auth-fallback", (_req, res) => {
+          attempt++;
+          if (attempt === 1) {
+            return res.status(401).json({ error: "Auth failed" });
+          }
+          res.status(200).json({ data: "public fallback" });
+        });
+
+        const { app } = await buildApp({
+          proxyAllDomains: true,
+          blacklistedAddresses: ["202.168.1.1"]
+        });
+
+        const response = await supertestReq(app)
+          [
+            methodName
+          ](`/proxy/localhost:${TEST_SERVER_PORT}/cache-auth-fallback`)
+          .set("Authorization", "Bearer bad-token")
+          .expect(200)
+          .expect("Cache-Control", "public,max-age=1209600");
+
+        expect(response.headers["vary"] ?? "").not.toContain("Authorization");
+      });
+
+      it("uses public cache-control and no Vary: Authorization when no auth is involved", async () => {
+        testServer.addRoute(methodName, "/cache-no-auth", (_req, res) => {
+          res.status(200).json({ data: "public" });
+        });
+
+        const { app } = await buildApp({
+          proxyAllDomains: true,
+          blacklistedAddresses: ["202.168.1.1"]
+        });
+
+        const response = await supertestReq(app)
+          [methodName](`/proxy/localhost:${TEST_SERVER_PORT}/cache-no-auth`)
+          .expect(200)
+          .expect("Cache-Control", "public,max-age=1209600");
+        expect(response.headers["vary"] ?? "").not.toContain("Authorization");
+      });
+    });
+
     it("No User Auth, No Proxy Auth defined -> First No Auth attempt (fails) -> Final 403 (no retry)", async () => {
       testServer.addRoute(methodName, "/auth-path4", (req, res) => {
         // No auth header expected, request should fail


### PR DESCRIPTION
### Problem

The proxy unconditionally set `Cache-Control: public` on all responses, including those obtained with authentication credentials. The `public` directive explicitly overrides RFC 7234 §3.2's built-in protection that prevents shared caches from storing responses to requests with an `Authorization` header.

Any shared cache in front of terriajs-server (CDN, reverse proxy) could store an auth-gated response and serve it to unauthenticated users making the same request.

**Attack scenario:**
1. User A authenticates and requests `GET /proxy/https://protected-backend/data`
2. Proxy responds with `Cache-Control: public, max-age=1209600`
3. A CDN or reverse proxy caches the response
4. User B (unauthenticated) makes the same request — the CDN serves User A's protected data

### Fix

When an authenticated strategy wins, the proxy now emits `Cache-Control: private` instead of `public`, preventing shared caches from storing the response.

`Vary: Authorization` is also added for client-supplied auth as defence-in-depth against misbehaving shared caches that ignore `private`. Server-configured proxy credentials (`proxyAuth`) are constant and not client-visible, so they get `private` only — adding `Vary: Authorization` there would be semantically incorrect and cause unnecessary cache fragmentation.

| Strategy that succeeded | `Cache-Control` | `Vary` |
|---|---|---|
| Client `Authorization` header | `private, max-age=…` | `Authorization` |
| Server-configured proxy auth | `private, max-age=…` | — |
| No auth | `public, max-age=…` | — |

### Known limitation

`Cache-Control: private` still permits browser-level caching. On a shared computer, a second user could retrieve a cached authenticated response from the browser. Full prevention requires `Cache-Control: no-store`, which is a separate performance trade-off.
