### PR TITLE
feat: store s3 clients in map

### DIFF
--- a/lib/controllers/share.js
+++ b/lib/controllers/share.js
@@ -92,7 +92,13 @@ function shortId(body, length) {
   return fullkey.slice(0, length); // if length undefined, return the whole thing
 }
 
-function getS3Client(serviceOptions) {
+const _s3Clients = new Map();
+
+function getS3Client(prefix, serviceOptions) {
+  if (_s3Clients.has(prefix)) {
+    return _s3Clients.get(prefix);
+  }
+
   const config = {
     region: serviceOptions.region,
     forcePathStyle: serviceOptions.forcePathStyle ?? false
@@ -110,14 +116,16 @@ function getS3Client(serviceOptions) {
     };
   }
 
-  return new S3Client(config);
+  const client = new S3Client(config);
+  _s3Clients.set(prefix, client);
+  return client;
 }
 
 // We append some pseudo-dir prefixes into the actual object ID to avoid thousands of objects in a single pseudo-directory.
 // MyRaNdoMkey => M/y/MyRaNdoMkey
 const idToObject = (id) => id.replace(/^(.)(.)/, "$1/$2/$1$2");
 
-async function saveS3(serviceOptions, body) {
+async function saveS3(prefix, serviceOptions, body) {
   const id = shortId(body, serviceOptions.keyLength);
   const params = {
     Bucket: serviceOptions.bucket,
@@ -125,7 +133,7 @@ async function saveS3(serviceOptions, body) {
     Body: body
   };
 
-  const client = getS3Client(serviceOptions);
+  const client = getS3Client(prefix, serviceOptions);
   const command = new PutObjectCommand(params);
 
   try {
@@ -140,13 +148,13 @@ async function saveS3(serviceOptions, body) {
   }
 }
 
-async function resolveS3(serviceOptions, id) {
+async function resolveS3(prefix, serviceOptions, id) {
   const params = {
     Bucket: serviceOptions.bucket,
     Key: idToObject(id)
   };
 
-  const client = getS3Client(serviceOptions);
+  const client = getS3Client(prefix, serviceOptions);
   const command = new GetObjectCommand(params);
 
   try {
@@ -197,7 +205,7 @@ export default function (options) {
     const serviceOptions = options.shareUrlPrefixes[options.newShareUrlPrefix];
     const minter = {
       gist: makeGist,
-      s3: saveS3
+      s3: (so, body) => saveS3(options.newShareUrlPrefix, so, body)
     }[serviceOptions.service.toLowerCase()];
     try {
       const id = await minter(serviceOptions, req.body);
@@ -231,7 +239,7 @@ export default function (options) {
     } else {
       resolver = {
         gist: resolveGist,
-        s3: resolveS3
+        s3: (so, shareId) => resolveS3(prefix, so, shareId)
       }[serviceOptions.service.toLowerCase()];
     }
     try {

--- a/lib/controllers/share.js
+++ b/lib/controllers/share.js
@@ -92,13 +92,7 @@ function shortId(body, length) {
   return fullkey.slice(0, length); // if length undefined, return the whole thing
 }
 
-let _S3;
-
 function getS3Client(serviceOptions) {
-  if (_S3) {
-    return _S3;
-  }
-
   const config = {
     region: serviceOptions.region,
     forcePathStyle: serviceOptions.forcePathStyle ?? false
@@ -116,8 +110,7 @@ function getS3Client(serviceOptions) {
     };
   }
 
-  _S3 = new S3Client(config);
-  return _S3;
+  return new S3Client(config);
 }
 
 // We append some pseudo-dir prefixes into the actual object ID to avoid thousands of objects in a single pseudo-directory.

--- a/spec/share-s3.spec.js
+++ b/spec/share-s3.spec.js
@@ -1,4 +1,8 @@
-import { CreateBucketCommand, S3Client } from "@aws-sdk/client-s3";
+import {
+  CreateBucketCommand,
+  PutObjectCommand,
+  S3Client
+} from "@aws-sdk/client-s3";
 import { LocalstackContainer } from "@testcontainers/localstack";
 import supertestReq from "supertest";
 
@@ -53,10 +57,12 @@ describe("Share Module (e2e) - S3", () => {
       }
     });
 
-    const createBucketResponse = await client.send(
-      new CreateBucketCommand({ Bucket: "sample-bucket" })
-    );
-    expect(createBucketResponse.$metadata.httpStatusCode).toEqual(200);
+    const [bucket1, bucket2] = await Promise.all([
+      client.send(new CreateBucketCommand({ Bucket: "sample-bucket" })),
+      client.send(new CreateBucketCommand({ Bucket: "sample-bucket-2" }))
+    ]);
+    expect(bucket1.$metadata.httpStatusCode).toEqual(200);
+    expect(bucket2.$metadata.httpStatusCode).toEqual(200);
   }, 120000);
 
   it("should save and resolve share via s3 provider", async () => {
@@ -150,6 +156,102 @@ describe("Share Module (e2e) - S3", () => {
     expect(response.body.message).toContain(
       "not been configured to generate new share URLs"
     );
+  });
+
+  describe("multiple S3 prefixes with separate buckets", () => {
+    const idToObject = (id) => id.replace(/^(.)(.)/, "$1/$2/$1$2");
+
+    function buildMultiBucketApp() {
+      const opts = options.init(true);
+      return makeServer(
+        Object.assign({}, opts, {
+          wwwroot: "./spec/mockwwwroot",
+          hostName: "localhost",
+          port: "3001",
+          settings: {
+            shareUrlPrefixes: {
+              primary: {
+                service: "s3",
+                region: "us-east-1",
+                bucket: "sample-bucket",
+                endpoint: localstackContainer.getConnectionUri(),
+                accessKeyId: "test",
+                secretAccessKey: "test",
+                keyLength: 54,
+                forcePathStyle: true
+              },
+              secondary: {
+                service: "s3",
+                region: "us-east-1",
+                bucket: "sample-bucket-2",
+                endpoint: localstackContainer.getConnectionUri(),
+                accessKeyId: "test",
+                secretAccessKey: "test",
+                keyLength: 54,
+                forcePathStyle: true
+              }
+            },
+            newShareUrlPrefix: "primary",
+            shareMaxRequestSize: "200kb"
+          }
+        })
+      );
+    }
+
+    function secondaryClient() {
+      return new S3Client({
+        endpoint: localstackContainer.getConnectionUri(),
+        forcePathStyle: true,
+        region: "us-east-1",
+        credentials: { accessKeyId: "test", secretAccessKey: "test" }
+      });
+    }
+
+    it("resolves share stored in secondary bucket using secondary prefix", async () => {
+      const shareId = "ab1SecondaryTestShareId123456789012345678901234567890";
+      await secondaryClient().send(
+        new PutObjectCommand({
+          Bucket: "sample-bucket-2",
+          Key: idToObject(shareId),
+          Body: JSON.stringify({ source: "secondary bucket" })
+        })
+      );
+
+      await supertestReq(buildMultiBucketApp())
+        .get(`/share/secondary-${shareId}`)
+        .expect(200, { source: "secondary bucket" });
+    });
+
+    it("stores new share only in primary bucket", async () => {
+      const app = buildMultiBucketApp();
+      const { body } = await supertestReq(app)
+        .post("/share")
+        .send({ data: "primary only content" })
+        .expect(201);
+
+      const baseId = body.id.replace(/^primary-/, "");
+
+      await supertestReq(app).get(`/share/primary-${baseId}`).expect(200, {
+        data: "primary only content"
+      });
+
+      await supertestReq(app).get(`/share/secondary-${baseId}`).expect(404);
+    });
+
+    it("returns 404 when resolving secondary share id using primary prefix", async () => {
+      const shareId = "cd2SecondaryOnlyShareId1234567890123456789012345678901";
+      await secondaryClient().send(
+        new PutObjectCommand({
+          Bucket: "sample-bucket-2",
+          Key: idToObject(shareId),
+          Body: JSON.stringify({ source: "secondary only" })
+        })
+      );
+
+      await supertestReq(buildMultiBucketApp())
+        .get(`/share/primary-${shareId}`)
+        .expect(404);
+    });
   });
 
   afterAll(async () => {


### PR DESCRIPTION
If multiple S3 prefixes are configured, the first-arriving request locks the client; subsequent requests for other prefixes silently use the wrong region/credentials.
This PR replaces that singleton with a Map keyed by share URL prefix, so each prefix gets its own S3Client instance, created once and reused across requests. 