### PR TITLE
fix: prevent open redirect via Host header in redirectToHttps

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -19,6 +19,7 @@
 * Stop returning incorrect location in share urls. Now when generating share url, only share id is returned.
 * Define and export types for server config response.
 * Prevent proxy cache poisoning on authenticated response. When authentication is used as part of proxy request we will set Cache-Control to private so CDNs and other shared caches won't cache the response. This is to prevent a malicious user from poisoning the cache with a response that includes authentication credentials, which could then be served to other users. https://github.com/TerriaJS/terriajs-server/pull/353
+* Prevent open redirect via the `Host` header when `redirectToHttps` is enabled. The http→https redirect target is now validated against the configured `hostName` plus an optional `trustedHosts` list; requests with an unrecognized `Host` receive a 400 instead of being redirected to it.
 
 
 ### 4.0.3 - 2025-12-04

--- a/lib/makeserver.js
+++ b/lib/makeserver.js
@@ -56,12 +56,27 @@ export default function (options) {
 
   if (options.settings.redirectToHttps) {
     const httpAllowedHosts = options.settings.httpAllowedHosts || ["localhost"];
+    // Only redirect to hosts we recognize, so an attacker-supplied Host header
+    // cannot turn the https redirect into an open redirect to an arbitrary site.
+    const trustedHosts = new Set(
+      [
+        options.hostName,
+        options.settings.hostName,
+        ...(options.settings.trustedHosts || [])
+      ].filter(Boolean)
+    );
     app.use((req, res, next) => {
       if (httpAllowedHosts.includes(req.hostname)) {
         return next();
       }
 
       if (req.protocol !== "https") {
+        if (!trustedHosts.has(req.hostname)) {
+          console.warn(
+            `Refusing https redirect for unrecognized host "${req.hostname}".`
+          );
+          return res.status(400).send("Invalid host");
+        }
         const url = `https://${req.hostname}${req.url}`;
         res.redirect(301, url);
       } else {

--- a/serverconfig.json.example
+++ b/serverconfig.json.example
@@ -243,6 +243,14 @@
         "localhost"
     ],
 
+    // Hostnames this server trusts as its own, in addition to `hostName`.
+    // Used to constrain the http->https redirect target so an attacker-supplied `Host`
+    // header cannot turn it into an open redirect (requests for any other host get a 400).
+    // List any additional hostnames this server is legitimately served under.
+    "trustedHosts": [
+        "maps.example.com"
+    ],
+
     // An array of options which you to inform which additional parameters are appended to the url querystring.
     // By default no additional parameters are appended.
     // A regex pattern is used to test whether parameters should be attached. Set to "." to match everything

--- a/spec/redirect-to-https.spec.js
+++ b/spec/redirect-to-https.spec.js
@@ -1,0 +1,59 @@
+import supertestReq from "supertest";
+
+import makeServer from "../lib/makeserver.js";
+
+function buildApp(settings = {}, options = {}) {
+  return makeServer({ hostName: "terria.example", ...options, settings });
+}
+
+describe("redirectToHttps host validation", () => {
+  it("redirects http requests for the configured host to https", async () => {
+    const app = buildApp({ redirectToHttps: true, hostName: "terria.example" });
+
+    await supertestReq(app)
+      .get("/some/path")
+      .set("Host", "terria.example")
+      .expect(301)
+      .expect("Location", "https://terria.example/some/path");
+  });
+
+  it("rejects an unrecognized Host header with 400 instead of redirecting to it", async () => {
+    const app = buildApp({ redirectToHttps: true, hostName: "terria.example" });
+
+    const res = await supertestReq(app)
+      .get("/some/path")
+      .set("Host", "evil.example")
+      .expect(400);
+
+    expect(res.headers["location"]).toBeUndefined();
+  });
+
+  it("allows additional legitimate hosts via trustedHosts", async () => {
+    const app = buildApp({
+      redirectToHttps: true,
+      hostName: "terria.example",
+      trustedHosts: ["maps.terria.example"]
+    });
+
+    await supertestReq(app)
+      .get("/x")
+      .set("Host", "maps.terria.example")
+      .expect(301)
+      .expect("Location", "https://maps.terria.example/x");
+  });
+
+  it("does not reject hosts allowed to stay on http", async () => {
+    const app = buildApp({
+      redirectToHttps: true,
+      hostName: "terria.example",
+      httpAllowedHosts: ["localhost"]
+    });
+
+    const res = await supertestReq(app)
+      .get("/some/path")
+      .set("Host", "localhost");
+
+    expect(res.status).not.toBe(400);
+    expect(res.headers["location"]).toBeUndefined();
+  });
+});


### PR DESCRIPTION
The redirectToHttps middleware built its Location header from req.hostname, which is derived from the client-controlled Host (or X-Forwarded-Host) header. An attacker-supplied Host was echoed into a permanently-cached 301 redirect, allowing an open redirect to an arbitrary site (exploitable cross-user via shared-cache poisoning of the 301).

The redirect target is now validated against an allowlist computed once at startup from the configured hostName plus an optional trustedHosts list; unrecognized hosts receive a 400 instead of being redirected. Keeping the 301 is safe now that the target is validated.