### PR TITLE
feat: add security response headers via helmet with report-only CSP

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -22,6 +22,8 @@
 * Create the Express router per invocation in the `feedback`, `esri-token-auth`, `initfile` and `single-page-routing` controllers instead of sharing a module-level router. This prevents route handlers and middleware from accumulating on a shared router when a controller factory is called more than once (e.g. in tests).
 * Prevent open redirect via the `Host` header when `redirectToHttps` is enabled. The http→https redirect target is now validated against the configured `hostName` plus an optional `trustedHosts` list; requests with an unrecognized `Host` receive a 400 instead of being redirected to it.
 * Reject cross-origin (CSRF) requests to the state-changing endpoints `/share`, `/feedback` and `/esri-token-auth`. Their `Origin` (or `Referer`) is validated against the `trustedHosts` list; requests from an untrusted origin receive a 403. Requests without an `Origin`/`Referer` (non-browser clients) are unaffected.
+* Add security response headers via `helmet`: `X-Content-Type-Options: nosniff`, a `Referrer-Policy`, and a TerriaJS-tuned Content-Security-Policy. The CSP is sent in report-only mode by default (violations are logged via a new `/csp-report` endpoint) so it never breaks the map; it can be enforced or customised via the `securityHeaders` config. Framing and cross-origin isolation headers are intentionally left off to preserve iframe embedding and the cross-origin `/proxy`.
+
 
 ### 4.0.3 - 2025-12-04
 

--- a/lib/controllers/csp-report.js
+++ b/lib/controllers/csp-report.js
@@ -1,0 +1,29 @@
+import bodyParser from "body-parser";
+import express from "express";
+
+/**
+ * Receives Content-Security-Policy violation reports (sent by browsers to the
+ * CSP `report-uri`) and logs them, so operators can see what a deployment's CSP
+ * would block before switching it from report-only to enforcing.
+ *
+ * @returns {import('express').Router}
+ */
+export default function () {
+  const router = express.Router();
+  router.use(
+    bodyParser.json({
+      type: [
+        "application/csp-report",
+        "application/reports+json",
+        "application/json"
+      ],
+      limit: "100kb"
+    })
+  );
+  router.post("/", (req, res) => {
+    const report = (req.body && req.body["csp-report"]) || req.body;
+    console.warn("CSP violation report:", JSON.stringify(report));
+    res.status(204).end();
+  });
+  return router;
+}

--- a/lib/makeserver.js
+++ b/lib/makeserver.js
@@ -18,6 +18,8 @@ import feedback from "./controllers/feedback.js";
 import share from "./controllers/share.js";
 import singlePageRouting from "./controllers/single-page-routing.js";
 import { makeOriginAllowlist } from "./controllers/origin-allowlist.js";
+import cspReport from "./controllers/csp-report.js";
+import { buildSecurityHeaders } from "./security-headers.js";
 
 /* Creates and returns a single express server. */
 export default function (options) {
@@ -37,6 +39,9 @@ export default function (options) {
   app.disable("x-powered-by");
   app.use(compression());
   app.use(cors());
+  if (options.settings.securityHeaders !== false) {
+    app.use(buildSecurityHeaders(options.settings.securityHeaders || {}));
+  }
   app.disable("etag");
   if (options.verbose) {
     app.use(morgan("dev"));
@@ -63,6 +68,10 @@ export default function (options) {
   endpoint("/ping", (_req, res) => {
     res.status(200).send("OK");
   });
+
+  // Receive CSP violation reports. Mounted before authentication so browser
+  // report POSTs (which carry no credentials) are not rejected.
+  endpoint("/csp-report", cspReport());
 
   // We do this after the /ping service above so that ping can be used unauthenticated and without TLS for health checks.
 

--- a/lib/security-headers.js
+++ b/lib/security-headers.js
@@ -1,0 +1,95 @@
+import helmet from "helmet";
+
+const CSP_REPORT_PATH = "/csp-report";
+
+/**
+ * Content-Security-Policy directives tuned for a TerriaJS/Cesium application.
+ *
+ * Cesium and TerriaJS create web workers and render tiles/textures from `blob:`
+ * URLs, and the app connects to arbitrary data sources, so the policy is broad
+ * where the app legitimately is (connect/img/media) and restrictive where it
+ * can be (object-src, base-uri). It is served in report-only mode by default,
+ * so it never blocks — it only reports violations to `/csp-report` so operators
+ * can see what a given deployment actually needs before enforcing.
+ *
+ * @param {object} settings
+ * @returns {Record<string, string[]>}
+ */
+function buildCspDirectives(settings) {
+  const extraScriptSrc = settings.cspScriptSrc || [];
+  const frameAncestors = settings.cspFrameAncestors || ["'self'"];
+  return {
+    "default-src": ["'self'"],
+    "base-uri": ["'self'"],
+    "object-src": ["'none'"],
+    "script-src": [
+      "'self'",
+      "'unsafe-inline'",
+      "'unsafe-eval'",
+      "blob:",
+      ...extraScriptSrc
+    ],
+    "worker-src": ["'self'", "blob:"],
+    "child-src": ["'self'", "blob:"],
+    "style-src": ["'self'", "'unsafe-inline'", "https:"],
+    "img-src": ["'self'", "data:", "blob:", "https:", "http:"],
+    "font-src": ["'self'", "https:", "data:"],
+    "connect-src": [
+      "'self'",
+      "https:",
+      "http:",
+      "wss:",
+      "ws:",
+      "blob:",
+      "data:"
+    ],
+    "media-src": ["'self'", "https:", "blob:", "data:"],
+    "frame-src": ["'self'", "https:", "blob:"],
+    "frame-ancestors": frameAncestors,
+    "report-uri": [CSP_REPORT_PATH]
+  };
+}
+
+/**
+ * Builds the helmet middleware with a configuration safe for terriajs-server:
+ * a report-only CSP tuned for TerriaJS, plus the safe headers (nosniff,
+ * Referrer-Policy). The directives that would break this server's core features
+ * are disabled: frameguard (iframe embedding is supported), cross-origin
+ * resource/opener/embedder policies (the proxy serves resources cross-origin),
+ * and HSTS (kept under the existing redirectToHttps handling).
+ *
+ * Every default can be overridden per deployment: `settings.helmet` is a raw
+ * helmet options object that is applied last, so an operator can enable HSTS or
+ * frameguard, tighten a cross-origin policy, replace the CSP, adjust the
+ * Referrer-Policy, etc. HSTS defaults to false here because it is a sticky,
+ * non-reversible browser commitment with no report mode; it is already handled
+ * (gated) by the `redirectToHttps`/`strictTransportSecurity` settings, and can
+ * be enabled here via `securityHeaders.helmet.hsts`.
+ *
+ * @param {object} [settings] The `securityHeaders` server setting.
+ * @returns {import('express').RequestHandler}
+ */
+function buildSecurityHeaders(settings = {}) {
+  const cspEnabled = settings.contentSecurityPolicy !== false;
+  const reportOnly = settings.cspReportOnly !== false;
+
+  const defaults = {
+    contentSecurityPolicy: cspEnabled
+      ? {
+          useDefaults: false,
+          directives: buildCspDirectives(settings),
+          reportOnly
+        }
+      : false,
+    hsts: false,
+    frameguard: false,
+    crossOriginResourcePolicy: false,
+    crossOriginOpenerPolicy: false,
+    crossOriginEmbedderPolicy: false,
+    referrerPolicy: { policy: "strict-origin-when-cross-origin" }
+  };
+
+  return helmet({ ...defaults, ...(settings.helmet || {}) });
+}
+
+export { buildSecurityHeaders, CSP_REPORT_PATH };

--- a/package.json
+++ b/package.json
@@ -47,6 +47,7 @@
     "compression": "^1.8.1",
     "cors": "^2.8.6",
     "express": "^5.2.1",
+    "helmet": "^8.2.0",
     "json5": "^2.2.3",
     "morgan": "^1.11.0",
     "proj4-cli-defs": "^2.1.0",

--- a/serverconfig.json.example
+++ b/serverconfig.json.example
@@ -253,6 +253,33 @@
         "maps.example.com"
     ],
 
+    // Security response headers (via helmet). Enabled by default; set to false to disable entirely.
+    // A Content-Security-Policy tuned for TerriaJS/Cesium is sent in REPORT-ONLY mode by default, so
+    // it never blocks - it only reports violations to the /csp-report endpoint (logged server-side),
+    // letting you see what a deployment actually loads before enforcing. X-Frame-Options and the
+    // cross-origin isolation headers are intentionally left off, because iframe embedding is a
+    // supported feature and the /proxy endpoint serves resources cross-origin.
+    "securityHeaders": {
+        // Set to false to stop sending the Content-Security-Policy header at all.
+        "contentSecurityPolicy": true,
+        // Set to false to ENFORCE the CSP instead of report-only. Only do this after reviewing
+        // /csp-report output for your deployment - an over-tight CSP will silently break the map.
+        "cspReportOnly": true,
+        // Extra sources to add to `script-src` (e.g. an analytics host).
+        "cspScriptSrc": [],
+        // `frame-ancestors` directive. Defaults to ["'self'"]. Set to ["*"] (or specific origins)
+        // if this deployment is embedded in third-party sites via an iframe.
+        "cspFrameAncestors": ["'self'"],
+        // Raw helmet options, applied last, to override ANY policy for this deployment.
+        // See https://helmetjs.github.io/ . Examples:
+        //   Enable HSTS:            "hsts": { "maxAge": 31536000, "includeSubDomains": true }
+        //   Enforce frame denial:   "frameguard": { "action": "deny" }
+        //   Restrict cross-origin:  "crossOriginResourcePolicy": { "policy": "same-origin" }
+        // (HSTS is off by default here because it is a sticky, non-reversible commitment with no
+        //  report mode; it is also set by `redirectToHttps`/`strictTransportSecurity` on https.)
+        "helmet": {}
+    },
+
     // An array of options which you to inform which additional parameters are appended to the url querystring.
     // By default no additional parameters are appended.
     // A regex pattern is used to test whether parameters should be attached. Set to "." to match everything

--- a/spec/security-headers.spec.js
+++ b/spec/security-headers.spec.js
@@ -1,0 +1,81 @@
+import supertestReq from "supertest";
+
+import makeServer from "../lib/makeserver.js";
+
+function buildApp(settings = {}) {
+  return makeServer({ hostName: "localhost", settings });
+}
+
+describe("security headers", () => {
+  it("sets X-Content-Type-Options: nosniff", async () => {
+    await supertestReq(buildApp())
+      .get("/api/v1/ping")
+      .expect("X-Content-Type-Options", "nosniff");
+  });
+
+  it("sets a Referrer-Policy", async () => {
+    const res = await supertestReq(buildApp()).get("/api/v1/ping");
+    expect(res.headers["referrer-policy"]).toBeDefined();
+  });
+
+  it("sends CSP in report-only mode by default, pointing at the report endpoint", async () => {
+    const res = await supertestReq(buildApp()).get("/api/v1/ping");
+    const csp = res.headers["content-security-policy-report-only"];
+    expect(csp).toBeDefined();
+    expect(res.headers["content-security-policy"]).toBeUndefined();
+    expect(csp).toContain("report-uri /csp-report");
+    // TerriaJS/Cesium load workers and textures from blob: URLs
+    expect(csp).toContain("worker-src");
+    expect(csp).toContain("blob:");
+  });
+
+  it("does not send X-Frame-Options (iframe embedding is a supported feature)", async () => {
+    const res = await supertestReq(buildApp()).get("/api/v1/ping");
+    expect(res.headers["x-frame-options"]).toBeUndefined();
+  });
+
+  it("does not restrict cross-origin resource consumption (proxy serves cross-origin)", async () => {
+    const res = await supertestReq(buildApp()).get("/api/v1/ping");
+    expect(res.headers["cross-origin-resource-policy"]).toBeUndefined();
+  });
+
+  it("accepts a CSP violation report at /csp-report", async () => {
+    await supertestReq(buildApp())
+      .post("/csp-report")
+      .set("Content-Type", "application/csp-report")
+      .send(
+        JSON.stringify({
+          "csp-report": {
+            "document-uri": "https://terria.example/",
+            "violated-directive": "img-src",
+            "blocked-uri": "blob:"
+          }
+        })
+      )
+      .expect(204);
+  });
+
+  it("can be disabled via securityHeaders: false", async () => {
+    const res = await supertestReq(buildApp({ securityHeaders: false })).get(
+      "/api/v1/ping"
+    );
+    expect(res.headers["x-content-type-options"]).toBeUndefined();
+    expect(res.headers["content-security-policy-report-only"]).toBeUndefined();
+  });
+
+  it("lets an operator override any helmet option, e.g. enable HSTS", async () => {
+    const res = await supertestReq(
+      buildApp({ securityHeaders: { helmet: { hsts: { maxAge: 100 } } } })
+    ).get("/api/v1/ping");
+    expect(res.headers["strict-transport-security"]).toContain("max-age=100");
+  });
+
+  it("lets an operator opt in to frame denial via override", async () => {
+    const res = await supertestReq(
+      buildApp({
+        securityHeaders: { helmet: { frameguard: { action: "deny" } } }
+      })
+    ).get("/api/v1/ping");
+    expect(res.headers["x-frame-options"]).toBe("DENY");
+  });
+});

--- a/yarn.lock
+++ b/yarn.lock
@@ -1787,6 +1787,11 @@ headers-polyfill@^5.0.1:
     "@types/set-cookie-parser" "^2.4.10"
     set-cookie-parser "^3.0.1"
 
+helmet@^8.2.0:
+  version "8.3.0"
+  resolved "https://registry.yarnpkg.com/helmet/-/helmet-8.3.0.tgz#3842eea921e7c7015d11f217910c710c434efb26"
+  integrity sha512-Qgpiaws3Sm30Av8Eah6sjMCZZwjlBu+E68rhpCWBshY1lb09HtLwj5GviX0OyQIn+ulUS0iX0AxN5n3tLZzz1w==
+
 http-errors@^2.0.0, http-errors@^2.0.1, http-errors@~2.0.1:
   version "2.0.1"
   resolved "https://registry.yarnpkg.com/http-errors/-/http-errors-2.0.1.tgz#36d2f65bc909c8790018dd36fb4d93da6caae06b"


### PR DESCRIPTION
Adds baseline security headers (X-Content-Type-Options: nosniff, a Referrer-Policy) and a Content-Security-Policy tuned for TerriaJS/Cesium (blob: workers and textures, broad connect/img sources). The CSP is sent in report-only mode by default and never blocks; violations are POSTed by the browser to a new /csp-report endpoint and logged, so operators can see what a deployment actually loads before switching to enforcing (securityHeaders config).

Headers that would break core features are deliberately omitted: X-Frame-Options/frameguard (iframe embedding is supported), Cross-Origin-Resource/Opener/Embedder-Policy (the /proxy serves resources cross-origin), and HSTS (kept under the existing redirectToHttps handling). The whole feature can be disabled with securityHeaders: false.